### PR TITLE
Completed pending admin-jobs carousel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextjs-app-template",
       "version": "0.1.0",
       "dependencies": {
+        "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/next-js": "^2.4.2",
         "@chakra-ui/react": "^2.10.4",
         "@clerk/nextjs": "^6.9.10",
@@ -20,6 +21,9 @@
         "react": "^18",
         "react-dom": "^18",
         "react-icons": "^5.4.0",
+        "react-responsive-carousel": "^3.2.23",
+        "react-slick": "^0.30.3",
+        "slick-carousel": "^1.8.1",
         "tailwind-merge": "^2.6.0"
       },
       "devDependencies": {
@@ -199,6 +203,16 @@
         "framesync": "6.1.2"
       },
       "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.2.4.tgz",
+      "integrity": "sha512-l5QdBgwrAg3Sc2BRqtNkJpfuLw/pWRDwwT58J6c4PqQT6wzXxyNa8Q0PForu1ltB5qEiFb1kxr/F/HO1EwNa6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@chakra-ui/react": ">=2.0.0",
         "react": ">=18"
       }
     },
@@ -1917,6 +1931,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -2357,6 +2377,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw==",
+      "license": "MIT"
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -4190,6 +4216,13 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/js-cookie": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
@@ -4249,6 +4282,15 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "1.0.2",
@@ -4492,6 +4534,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5665,6 +5713,18 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-easy-swipe": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz",
+      "integrity": "sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.5.8"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
@@ -5748,6 +5808,34 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-responsive-carousel": {
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.2.23.tgz",
+      "integrity": "sha512-pqJLsBaKHWJhw/ItODgbVoziR2z4lpcJg+YwmRlSk4rKH32VE633mAtZZ9kDXjy4wFO+pgUZmDKPsPe1fPmHCg==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.5.8",
+        "react-easy-swipe": "^0.0.21"
+      }
+    },
+    "node_modules/react-slick": {
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.30.3.tgz",
+      "integrity": "sha512-B4x0L9GhkEWUMApeHxr/Ezp2NncpGc+5174R02j+zFiWuYboaq98vmxwlpafZfMjZic1bjdIqqmwLDcQY0QaFA==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-style-singleton": {
@@ -5837,6 +5925,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -6155,6 +6249,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jquery": ">=1.8.0"
+      }
+    },
     "node_modules/snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -6250,6 +6353,12 @@
       "engines": {
         "node": ">=0.6.19"
       }
+    },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^2.2.4",
     "@chakra-ui/next-js": "^2.4.2",
     "@chakra-ui/react": "^2.10.4",
     "@clerk/nextjs": "^6.9.10",
@@ -25,6 +26,9 @@
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^5.4.0",
+    "react-responsive-carousel": "^3.2.23",
+    "react-slick": "^0.30.3",
+    "slick-carousel": "^1.8.1",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {

--- a/src/app/admin-jobs/page.tsx
+++ b/src/app/admin-jobs/page.tsx
@@ -37,7 +37,7 @@ export default function AdminJobs() {
           <div className="flex flex-col gap-8">
             <div className="text-2xl font-semibold">Incoming Applications</div>
             {incomingJobData ? (
-              <ChakraCarousel gap={25}>
+              <ChakraCarousel gap={20}>
                 {incomingJobData.map((job) => (
                   <Flex
                     key={job._id}
@@ -49,7 +49,7 @@ export default function AdminJobs() {
                     rounded={5}
                     flex={1}
                   >
-                    <AdminJobCard key={job._id} job={job} />
+                    <AdminJobCard job={job} />
                   </Flex>
                 ))}
               </ChakraCarousel>

--- a/src/app/admin-jobs/page.tsx
+++ b/src/app/admin-jobs/page.tsx
@@ -5,6 +5,7 @@ import AdminJobCard from "@/components/JobCard/AdminCard";
 import JobGrid from "@/components/JobGrid";
 import { Loader } from "@/components/Loader";
 import { IJob } from "@/database/jobSchema";
+import { Flex } from "@chakra-ui/react";
 
 // Helper function to filter the job data into the three categories
 function filterJobs(jobs: IJob[], filterBy: "pending" | "approved" | "rejected") {
@@ -36,9 +37,20 @@ export default function AdminJobs() {
           <div className="flex flex-col gap-8">
             <div className="text-2xl font-semibold">Incoming Applications</div>
             {incomingJobData ? (
-              <ChakraCarousel gap={16}>
+              <ChakraCarousel gap={25}>
                 {incomingJobData.map((job) => (
-                  <AdminJobCard key={job._id} job={job} />
+                  <Flex
+                    key={job._id}
+                    justifyContent="space-between"
+                    flexDirection="column"
+                    overflow="hidden"
+                    color="gray.300"
+                    bg="base.d100"
+                    rounded={5}
+                    flex={1}
+                  >
+                    <AdminJobCard key={job._id} job={job} />
+                  </Flex>
                 ))}
               </ChakraCarousel>
             ) : (

--- a/src/app/admin-jobs/page.tsx
+++ b/src/app/admin-jobs/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 import { useState, useEffect } from "react";
+import ChakraCarousel from "@/components/ChakraCarousel/carousel";
+import JobCard from "@/components/JobCard/JobCard"; // or your custom job item component
 import JobGrid from "@/components/JobGrid";
-import { IJob } from "@/database/jobSchema";
 import { Loader } from "@/components/Loader";
+import { IJob } from "@/database/jobSchema";
 
 // Helper function to filter the job data into the three categories
 function filterJobs(jobs: IJob[], filterBy: "pending" | "approved" | "rejected") {
@@ -18,12 +20,9 @@ export default function AdminJobs() {
     const fetchData = async () => {
       const response = await fetch("/api/jobs");
       const result = await response.json();
-      const incoming = filterJobs(result, "pending");
-      const live = filterJobs(result, "approved");
-      const complete = filterJobs(result, "rejected");
-      setIncomingJobData(incoming);
-      setLiveJobData(live);
-      setCompleteJobData(complete);
+      setIncomingJobData(filterJobs(result, "pending"));
+      setLiveJobData(filterJobs(result, "approved"));
+      setCompleteJobData(filterJobs(result, "rejected"));
     };
 
     fetchData();
@@ -33,111 +32,53 @@ export default function AdminJobs() {
     <div className="w-full">
       <div className="mt-20 px-8 md:px-16 lg:px-20 flex flex-col gap-16 text-black">
         <div className="flex flex-col gap-16 mb-20">
-          {/* Incoming jobs use the carousel */}
-          <JobSection jobs={incomingJobData} title="Incoming Applications" isCarousel />
-          {/* Live and complete jobs use the standard grid */}
-          <JobSection jobs={liveJobData} title="Live Applications" />
-          <JobSection jobs={completeJobData} title="Complete Applications" />
+          {/* Incoming Applications with Carousel */}
+          <div className="flex flex-col gap-8">
+            <div className="text-2xl font-semibold">Incoming Applications</div>
+            {incomingJobData ? (
+              <ChakraCarousel gap={16}>
+                {incomingJobData.map((job) => (
+                  <JobCard key={job._id} job={job} />
+                ))}
+              </ChakraCarousel>
+            ) : (
+              <Loader
+                size="md"
+                label="Loading Jobs..."
+                className="mt-8 grow flex flex-col gap-6 justify-center items-center"
+              />
+            )}
+          </div>
+
+          {/* Live Applications rendered as a grid */}
+          <div className="flex flex-col gap-8">
+            <div className="text-2xl font-semibold">Live Applications</div>
+            {liveJobData ? (
+              <JobGrid jobs={liveJobData} isAdmin={true} />
+            ) : (
+              <Loader
+                size="md"
+                label="Loading Jobs..."
+                className="mt-8 grow flex flex-col gap-6 justify-center items-center"
+              />
+            )}
+          </div>
+
+          {/* Complete Applications rendered as a grid */}
+          <div className="flex flex-col gap-8">
+            <div className="text-2xl font-semibold">Complete Applications</div>
+            {completeJobData ? (
+              <JobGrid jobs={completeJobData} isAdmin={true} />
+            ) : (
+              <Loader
+                size="md"
+                label="Loading Jobs..."
+                className="mt-8 grow flex flex-col gap-6 justify-center items-center"
+              />
+            )}
+          </div>
         </div>
       </div>
     </div>
   );
 }
-
-interface JobSectionProps {
-  title: string;
-  jobs?: IJob[] | null;
-  isCarousel?: boolean;
-}
-
-const JobSection = ({ title, jobs, isCarousel }: JobSectionProps) => {
-  return (
-    <div className="flex flex-col gap-8">
-      <h2 className="text-2xl font-semibold">{title}</h2>
-      {jobs ? (
-        isCarousel ? (
-          <JobCarousel jobs={jobs} />
-        ) : (
-          <JobGrid jobs={jobs} isAdmin={true} />
-        )
-      ) : (
-        <Loader
-          size="md"
-          label="Loading Jobs..."
-          className="mt-8 grow flex flex-col gap-6 justify-center items-center"
-        />
-      )}
-    </div>
-  );
-};
-
-// here is the carouel functionality
-// it recieves a jobs prop which is an array of job objects
-interface JobCarouselProps {
-  jobs: IJob[];
-}
-
-const JobCarousel = ({ jobs }: JobCarouselProps) => {
-  const [currentIndex, setCurrentIndex] = useState(0);
-  // Default to showing 2 items on desktop
-  const [itemsToShow, setItemsToShow] = useState(2);
-
-  // Adjust the number of items based on the viewport width
-  useEffect(() => {
-    const handleResize = () => {
-      if (window.innerWidth < 768) {
-        setItemsToShow(1);
-      } else {
-        setItemsToShow(2);
-      }
-    };
-
-    // Set the initial number of items
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
-  // Ensure the currentIndex remains valid if the jobs list or itemsToShow change
-  useEffect(() => {
-    if (currentIndex > jobs.length - itemsToShow) {
-      setCurrentIndex(Math.max(0, jobs.length - itemsToShow));
-    }
-  }, [itemsToShow, jobs, currentIndex]);
-
-  const visibleJobs = jobs.slice(currentIndex, currentIndex + itemsToShow);
-
-  const canGoPrev = currentIndex > 0;
-  const canGoNext = currentIndex + itemsToShow < jobs.length;
-
-  const handlePrev = () => {
-    setCurrentIndex(Math.max(currentIndex - itemsToShow, 0));
-  };
-
-  const handleNext = () => {
-    setCurrentIndex(Math.min(currentIndex + itemsToShow, jobs.length - itemsToShow));
-  };
-
-  return (
-    <div className="relative">
-      {/* Render the currently visible jobs */}
-      <JobGrid jobs={visibleJobs} isAdmin={true} />
-      <div className="flex justify-between mt-4">
-        <button
-          onClick={handlePrev}
-          disabled={!canGoPrev}
-          className="px-4 py-2 bg-gray-300 rounded disabled:opacity-50"
-        >
-          Prev
-        </button>
-        <button
-          onClick={handleNext}
-          disabled={!canGoNext}
-          className="px-4 py-2 bg-gray-300 rounded disabled:opacity-50"
-        >
-          Next
-        </button>
-      </div>
-    </div>
-  );
-};

--- a/src/app/admin-jobs/page.tsx
+++ b/src/app/admin-jobs/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
 import ChakraCarousel from "@/components/ChakraCarousel/carousel";
-import JobCard from "@/components/JobCard/JobCard"; // or your custom job item component
+import AdminJobCard from "@/components/JobCard/AdminCard";
 import JobGrid from "@/components/JobGrid";
 import { Loader } from "@/components/Loader";
 import { IJob } from "@/database/jobSchema";
@@ -32,13 +32,13 @@ export default function AdminJobs() {
     <div className="w-full">
       <div className="mt-20 px-8 md:px-16 lg:px-20 flex flex-col gap-16 text-black">
         <div className="flex flex-col gap-16 mb-20">
-          {/* Incoming Applications with Carousel */}
+          {/* Incoming Applications with Carousel using AdminJobCard */}
           <div className="flex flex-col gap-8">
             <div className="text-2xl font-semibold">Incoming Applications</div>
             {incomingJobData ? (
               <ChakraCarousel gap={16}>
                 {incomingJobData.map((job) => (
-                  <JobCard key={job._id} job={job} />
+                  <AdminJobCard key={job._id} job={job} />
                 ))}
               </ChakraCarousel>
             ) : (

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -44,8 +44,6 @@ export default function AdminJobs() {
                     justifyContent="space-between"
                     flexDirection="column"
                     overflow="hidden"
-                    color="gray.300"
-                    bg="base.d100"
                     rounded={5}
                     flex={1}
                   >

--- a/src/components/ChakraCarousel/carousel.js
+++ b/src/components/ChakraCarousel/carousel.js
@@ -184,13 +184,12 @@ const Slider = ({
           value={percentage(activeItem, positions.length - constraint)}
           alignSelf="center"
           borderRadius="2px"
-          bg="base.d100"
+          bg="gray.100"
           flex={1}
           h="3px"
           sx={{
             "> div": {
-              backgroundColor: "gray.400",
-              transition: "width 0.5s ease-in-out", // Smoothly animate width changes
+              backgroundColor: "black",
             },
           }}
         />

--- a/src/components/ChakraCarousel/carousel.js
+++ b/src/components/ChakraCarousel/carousel.js
@@ -184,12 +184,13 @@ const Slider = ({
           value={percentage(activeItem, positions.length - constraint)}
           alignSelf="center"
           borderRadius="2px"
-          bg="gray.100"
+          bg="gray.200"
           flex={1}
           h="3px"
           sx={{
             "> div": {
               backgroundColor: "black",
+              transition: "width 0.4s linear", // Smoothly animate width changes
             },
           }}
         />

--- a/src/components/ChakraCarousel/carousel.js
+++ b/src/components/ChakraCarousel/carousel.js
@@ -167,11 +167,17 @@ const Slider = ({
           onClick={handleDecrementClick}
           onFocus={handleFocus}
           mr={`${gap / 3}px`}
-          color="black.200"
           variant="link"
           minW={0}
+          // When pressed, the svg (arrow icon) will have no fill and a black stroke.
+          _active={{
+            svg: {
+              fill: "none",
+              stroke: "black",
+            },
+          }}
         >
-          <ChevronLeftIcon boxSize={9} />
+          <ChevronLeftIcon boxSize={9} color="black" />
         </Button>
 
         <Progress
@@ -184,6 +190,7 @@ const Slider = ({
           sx={{
             "> div": {
               backgroundColor: "gray.400",
+              transition: "width 0.5s ease-in-out", // Smoothly animate width changes
             },
           }}
         />
@@ -192,12 +199,18 @@ const Slider = ({
           onClick={handleIncrementClick}
           onFocus={handleFocus}
           ml={`${gap / 3}px`}
-          color="black.200"
           variant="link"
           zIndex={2}
           minW={0}
+          // Apply the same active styles to the right arrow.
+          _active={{
+            svg: {
+              fill: "none",
+              stroke: "black",
+            },
+          }}
         >
-          <ChevronRightIcon boxSize={9} />
+          <ChevronRightIcon boxSize={9} color="black" />
         </Button>
       </Flex>
     </>

--- a/src/components/ChakraCarousel/carousel.js
+++ b/src/components/ChakraCarousel/carousel.js
@@ -1,0 +1,366 @@
+import React, { useLayoutEffect, useCallback, useEffect, useState, useMemo, useRef } from "react";
+
+import { useMediaQuery, useTheme, Progress, VStack, Button, Flex, Box } from "@chakra-ui/react";
+
+import { ChevronRightIcon, ChevronLeftIcon } from "@chakra-ui/icons";
+import { motion, useAnimation, useMotionValue } from "framer-motion";
+import useBoundingRect from "./hooks/useBoundingRect";
+import percentage from "./utils/percentage";
+
+const MotionFlex = motion(Flex);
+
+const transitionProps = {
+  stiffness: 400,
+  type: "spring",
+  damping: 60,
+  mass: 3,
+};
+
+const ChakraCarousel = ({ children, gap }) => {
+  const [trackIsActive, setTrackIsActive] = useState(false);
+  const [multiplier, setMultiplier] = useState(0.35);
+  const [sliderWidth, setSliderWidth] = useState(0);
+  const [activeItem, setActiveItem] = useState(0);
+  const [constraint, setConstraint] = useState(0);
+  const [itemWidth, setItemWidth] = useState(0);
+
+  const initSliderWidth = useCallback((width) => setSliderWidth(width), []);
+
+  // Calculate positions for each child based on item width and gap
+  const positions = useMemo(
+    () => children.map((_, index) => -Math.abs((itemWidth + gap) * index)),
+    [children, itemWidth, gap],
+  );
+
+  const { breakpoints } = useTheme();
+  // Define mobile as any viewport smaller than the md breakpoint.
+  const [isMobile] = useMediaQuery(`(max-width: ${breakpoints.md})`);
+
+  useEffect(() => {
+    if (isMobile) {
+      // Mobile: show 1 job (full width)
+      setItemWidth(sliderWidth - gap);
+      setMultiplier(0.65);
+      setConstraint(1);
+    } else {
+      // Web: show 2 jobs side-by-side
+      setItemWidth(sliderWidth / 2 - gap);
+      setMultiplier(0.5);
+      setConstraint(2);
+    }
+  }, [isMobile, sliderWidth, gap]);
+
+  const sliderProps = {
+    setTrackIsActive,
+    initSliderWidth,
+    setActiveItem,
+    activeItem,
+    constraint,
+    itemWidth,
+    positions,
+    gap,
+  };
+
+  const trackProps = {
+    setTrackIsActive,
+    trackIsActive,
+    setActiveItem,
+    sliderWidth,
+    activeItem,
+    constraint,
+    multiplier,
+    itemWidth,
+    positions,
+    gap,
+  };
+
+  const itemProps = {
+    setTrackIsActive,
+    trackIsActive,
+    setActiveItem,
+    activeItem,
+    constraint,
+    itemWidth,
+    positions,
+    gap,
+  };
+
+  return (
+    <Slider {...sliderProps}>
+      <Track {...trackProps}>
+        {children.map((child, index) => (
+          <Item {...itemProps} index={index} key={index}>
+            {child}
+          </Item>
+        ))}
+      </Track>
+    </Slider>
+  );
+};
+
+const Slider = ({
+  setTrackIsActive,
+  initSliderWidth,
+  setActiveItem,
+  activeItem,
+  constraint,
+  itemWidth,
+  positions,
+  children,
+  gap,
+}) => {
+  const [ref, { width }] = useBoundingRect();
+
+  useLayoutEffect(() => initSliderWidth(Math.round(width)), [width, initSliderWidth]);
+
+  const handleFocus = () => setTrackIsActive(true);
+
+  const handleDecrementClick = () => {
+    setTrackIsActive(true);
+    if (activeItem !== 0) {
+      setActiveItem((prev) => prev - 1);
+    }
+  };
+
+  const handleIncrementClick = () => {
+    setTrackIsActive(true);
+    if (activeItem !== positions.length - constraint) {
+      setActiveItem((prev) => prev + 1);
+    }
+  };
+
+  return (
+    <>
+      <Box
+        ref={ref}
+        w={{ base: "100%", md: `calc(100% + ${gap}px)` }}
+        ml={{ base: 0, md: `-${gap / 2}px` }}
+        px={`${gap / 2}px`}
+        position="relative"
+        overflow="hidden"
+        _before={{
+          bgGradient: "linear(to-r, base.d400, transparent)",
+          position: "absolute",
+          w: `${gap / 2}px`,
+          content: "''",
+          zIndex: 1,
+          h: "100%",
+          left: 0,
+          top: 0,
+        }}
+        _after={{
+          bgGradient: "linear(to-l, base.d400, transparent)",
+          position: "absolute",
+          w: `${gap / 2}px`,
+          content: "''",
+          zIndex: 1,
+          h: "100%",
+          right: 0,
+          top: 0,
+        }}
+      >
+        {children}
+      </Box>
+
+      <Flex w={`${itemWidth}px`} mt={`${gap / 2}px`} mx="auto">
+        <Button
+          onClick={handleDecrementClick}
+          onFocus={handleFocus}
+          mr={`${gap / 3}px`}
+          color="black.200"
+          variant="link"
+          minW={0}
+        >
+          <ChevronLeftIcon boxSize={9} />
+        </Button>
+
+        <Progress
+          value={percentage(activeItem, positions.length - constraint)}
+          alignSelf="center"
+          borderRadius="2px"
+          bg="base.d100"
+          flex={1}
+          h="3px"
+          sx={{
+            "> div": {
+              backgroundColor: "gray.400",
+            },
+          }}
+        />
+
+        <Button
+          onClick={handleIncrementClick}
+          onFocus={handleFocus}
+          ml={`${gap / 3}px`}
+          color="black.200"
+          variant="link"
+          zIndex={2}
+          minW={0}
+        >
+          <ChevronRightIcon boxSize={9} />
+        </Button>
+      </Flex>
+    </>
+  );
+};
+
+const Track = ({
+  setTrackIsActive,
+  trackIsActive,
+  setActiveItem,
+  activeItem,
+  constraint,
+  multiplier,
+  itemWidth,
+  positions,
+  children,
+}) => {
+  const [dragStartPosition, setDragStartPosition] = useState(0);
+  const controls = useAnimation();
+  const x = useMotionValue(0);
+  const node = useRef(null);
+
+  const handleDragStart = () => setDragStartPosition(positions[activeItem]);
+
+  const handleDragEnd = (_, info) => {
+    const distance = info.offset.x;
+    const velocity = info.velocity.x * multiplier;
+    const direction = velocity < 0 || distance < 0 ? 1 : -1;
+
+    const extrapolatedPosition =
+      dragStartPosition + (direction === 1 ? Math.min(velocity, distance) : Math.max(velocity, distance));
+
+    const closestPosition = positions.reduce(
+      (prev, curr) => (Math.abs(curr - extrapolatedPosition) < Math.abs(prev - extrapolatedPosition) ? curr : prev),
+      0,
+    );
+
+    if (!(closestPosition < positions[positions.length - constraint])) {
+      setActiveItem(positions.indexOf(closestPosition));
+      controls.start({
+        x: closestPosition,
+        transition: { velocity: info.velocity.x, ...transitionProps },
+      });
+    } else {
+      setActiveItem(positions.length - constraint);
+      controls.start({
+        x: positions[positions.length - constraint],
+        transition: { velocity: info.velocity.x, ...transitionProps },
+      });
+    }
+  };
+
+  const handleResize = useCallback(
+    () =>
+      controls.start({
+        x: positions[activeItem],
+        transition: { ...transitionProps },
+      }),
+    [activeItem, controls, positions],
+  );
+
+  const handleClick = useCallback(
+    (event) => (node.current.contains(event.target) ? setTrackIsActive(true) : setTrackIsActive(false)),
+    [setTrackIsActive],
+  );
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (trackIsActive) {
+        if (activeItem < positions.length - constraint) {
+          if (event.key === "ArrowRight" || event.key === "ArrowUp") {
+            event.preventDefault();
+            setActiveItem((prev) => prev + 1);
+          }
+        }
+        if (activeItem > 0) {
+          if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
+            event.preventDefault();
+            setActiveItem((prev) => prev - 1);
+          }
+        }
+      }
+    },
+    [trackIsActive, setActiveItem, activeItem, constraint, positions.length],
+  );
+
+  useEffect(() => {
+    handleResize();
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("mousedown", handleClick);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("mousedown", handleClick);
+    };
+  }, [handleClick, handleResize, handleKeyDown, positions]);
+
+  return (
+    <>
+      {itemWidth && (
+        <VStack ref={node} spacing={5} alignItems="stretch">
+          <MotionFlex
+            dragConstraints={node}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            animate={controls}
+            style={{ x }}
+            drag="x"
+            _active={{ cursor: "grabbing" }}
+            minWidth="min-content"
+            flexWrap="nowrap"
+            cursor="grab"
+          >
+            {children}
+          </MotionFlex>
+        </VStack>
+      )}
+    </>
+  );
+};
+
+const Item = ({
+  setTrackIsActive,
+  setActiveItem,
+  activeItem,
+  constraint,
+  itemWidth,
+  positions,
+  children,
+  index,
+  gap,
+}) => {
+  const [userDidTab, setUserDidTab] = useState(false);
+
+  const handleFocus = () => setTrackIsActive(true);
+
+  const handleBlur = () => {
+    if (userDidTab && index + 1 === positions.length) {
+      setTrackIsActive(false);
+    }
+    setUserDidTab(false);
+  };
+
+  const handleKeyUp = (event) => {
+    if (event.key === "Tab" && activeItem !== positions.length - constraint) {
+      setActiveItem(index);
+    }
+  };
+
+  const handleKeyDown = (event) => event.key === "Tab" && setUserDidTab(true);
+
+  return (
+    <Flex
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      onKeyUp={handleKeyUp}
+      onKeyDown={handleKeyDown}
+      w={`${itemWidth}px`}
+      _notLast={{ mr: `${gap}px` }}
+      py="4px"
+    >
+      {children}
+    </Flex>
+  );
+};
+
+export default ChakraCarousel;

--- a/src/components/ChakraCarousel/hooks/index.js
+++ b/src/components/ChakraCarousel/hooks/index.js
@@ -1,0 +1,1 @@
+export { default as useBoundingRect } from "./useBoundingRect";

--- a/src/components/ChakraCarousel/hooks/useBoundingRect.js
+++ b/src/components/ChakraCarousel/hooks/useBoundingRect.js
@@ -1,0 +1,53 @@
+import { useState, useCallback, useLayoutEffect } from "react";
+
+const debounce = (limit, callback) => {
+  let timeoutId;
+  return (...args) => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    timeoutId = setTimeout(callback, limit, args);
+  };
+};
+
+function getDimensionObject(node) {
+  const rect = node.getBoundingClientRect();
+  return {
+    width: rect.width,
+    height: rect.height,
+    top: rect.top,
+    left: rect.left,
+    x: rect.x,
+    y: rect.y,
+    right: rect.right,
+    bottom: rect.bottom,
+  };
+}
+
+export default function useBoundingRect(limit) {
+  const [dimensions, setDimensions] = useState({});
+  const [node, setNode] = useState(null);
+
+  const ref = useCallback((node) => {
+    setNode(node);
+  }, []);
+
+  useLayoutEffect(() => {
+    if ("undefined" !== typeof window && node) {
+      const measure = () => window.requestAnimationFrame(() => setDimensions(getDimensionObject(node)));
+
+      measure();
+
+      const listener = debounce(limit ? limit : 100, measure);
+
+      window.addEventListener("resize", listener);
+      window.addEventListener("scroll", listener);
+      return () => {
+        window.removeEventListener("resize", listener);
+        window.removeEventListener("scroll", listener);
+      };
+    }
+  }, [node, limit]);
+
+  return [ref, dimensions, node];
+}

--- a/src/components/ChakraCarousel/utils/capsFirst.js
+++ b/src/components/ChakraCarousel/utils/capsFirst.js
@@ -1,3 +1,0 @@
-export default function capsFirst(str) {
-  return str.charAt(0).toUpperCase() + str.slice(1);
-}

--- a/src/components/ChakraCarousel/utils/capsFirst.js
+++ b/src/components/ChakraCarousel/utils/capsFirst.js
@@ -1,0 +1,3 @@
+export default function capsFirst(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/src/components/ChakraCarousel/utils/debounce.js
+++ b/src/components/ChakraCarousel/utils/debounce.js
@@ -1,0 +1,9 @@
+export default function debounce(limit, callback) {
+  let timeoutId;
+  return (...args) => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    timeoutId = setTimeout(callback, limit, args);
+  };
+}

--- a/src/components/ChakraCarousel/utils/index.js
+++ b/src/components/ChakraCarousel/utils/index.js
@@ -1,0 +1,3 @@
+export { default as debounce } from "./debounce";
+export { default as capsFirst } from "./capsFirst";
+export { default as percentage } from "./percentage";

--- a/src/components/ChakraCarousel/utils/index.js
+++ b/src/components/ChakraCarousel/utils/index.js
@@ -1,3 +1,2 @@
 export { default as debounce } from "./debounce";
-export { default as capsFirst } from "./capsFirst";
 export { default as percentage } from "./percentage";

--- a/src/components/ChakraCarousel/utils/percentage.js
+++ b/src/components/ChakraCarousel/utils/percentage.js
@@ -1,0 +1,3 @@
+export default function percentage(x, y) {
+  return 100 / (y / x);
+}

--- a/src/components/NavBar/BottomSection.tsx
+++ b/src/components/NavBar/BottomSection.tsx
@@ -50,8 +50,8 @@ export default function BottomSection({ user, isAdmin }: BottomSectionProps) {
       </Link>
       {user && isAdmin && (
         <Link
-          href="admin-jobs"
-          className={`font-medium text-center w-1/2 sm:w-max text-lg py-5 sm:py-7 px-5 border-y-4 border-[#2B2B2B] hover:border-b-[#C3412E] ${isActive("/admin-jobs") ? "border-b-[#C3412E]" : ""}`}
+          href="admin"
+          className={`font-medium text-center w-1/2 sm:w-max text-lg py-5 sm:py-7 px-5 border-y-4 border-[#2B2B2B] hover:border-b-[#C3412E] ${isActive("/admin") ? "border-b-[#C3412E]" : ""}`}
         >
           View Applications
         </Link>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,12 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "src/components/ChakraCarousel/carousel.js"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
…shows 2 per desktop and 1 per mobile

## Developer: Kyler Nord

Closes # https://github.com/hack4impact-calpoly/spokes/issues/93

### Pull Request Summary

I completed the Horizontal carousel for the incoming jobs in admin-jobs.
It shows 2 jobs per slide when on desktop and 1 job per slide when on mobile.


### Modifications

I modified the page.tsx under admin-jobs, I also made a carousel component under components

### Testing Considerations

I tested my carousel on both desktop and on mobile. Because there are only 2 incoming jobs on desktop it'd hard to show you being able to go to the next one, but you can see its full functionality on mobile with the vide that I attached.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast


https://github.com/user-attachments/assets/08384302-d719-4dbc-99d9-d2e04bf12430


https://github.com/user-attachments/assets/bb57340b-a739-4c00-839a-5cc2b8d4e187




