### PR TITLE
95 fetch recent jobs and display on jobs page john ieng

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,7 @@ const nextConfig = {
       },
     ];
   },
+  reactStrictMode: true,
 };
 
 module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -12,7 +12,6 @@ const nextConfig = {
       },
     ];
   },
-  reactStrictMode: true,
 };
 
 module.exports = nextConfig;

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -28,22 +28,7 @@ export default function Jobs() {
       const result = await response.json();
       setJobData(result);
 
-      // Get recent viewed job IDs from local storage
-      const raw = localStorage.getItem("myJobs");
-      const recentJobIds = raw ? JSON.parse(raw) : [];
-
-      // Query for recent jobs if one or more IDs are present
-      if (recentJobIds.length > 0) {
-        const recentJobsresponse = await fetch("/api/jobs/recent", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ rawJobIdArray: recentJobIds }),
-        });
-        const recentJobsResult = await recentJobsresponse.json();
-        setRecentJobs(recentJobsResult);
-      } else {
-        setRecentJobs([]);
-      }
+      fetchRecentJobs();
     };
     fetchData();
   }, []);
@@ -58,6 +43,25 @@ export default function Jobs() {
   const filterCategories: FilterCategories = {
     employment: ["Full-time", "Part-time", "Volunteer"],
     compensation: ["Paid", "Non-paid"],
+  };
+
+  // Handler to fetch recent jobs by IDs
+  const fetchRecentJobs = async () => {
+    // Get recent viewed job IDs from local storage
+    const raw = localStorage.getItem("myJobs");
+    const recentJobIds = raw ? JSON.parse(raw) : [];
+
+    if (recentJobIds.length > 0) {
+      const recentJobsresponse = await fetch("/api/jobs/recent", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rawJobIdArray: recentJobIds }),
+      });
+      const recentJobsResult = await recentJobsresponse.json();
+      setRecentJobs(recentJobsResult);
+    } else {
+      setRecentJobs([]);
+    }
   };
 
   const handleFilterChange = (category: string, value: string) => {
@@ -113,9 +117,10 @@ export default function Jobs() {
                 "text-black text-3xl cursor-pointer select-none",
                 tab == 2 ? "font-semibold" : "font-normal text-[#C3C3C3]",
               )}
-              onClick={() => {
-                // Later add functionally to display listings
+              onClick={async () => {
+                // trigger refetch to ensure display of fresh data
                 setTab(2);
+                await fetchRecentJobs();
               }}
             >
               Recently Viewed

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -20,56 +20,31 @@ export default function Jobs() {
 
   const [jobData, setJobData] = useState<null | IJob[]>(null);
 
-  const [recentJobs, setRecentJobs] = useState<IJob[]>([
-    // Hardcoded recently viewed jobs
-    {
-      _id: "1",
-      organizationName: "Tech Corp",
-      organizationIndustry: "Technology",
-      title: "Software Engineer",
-      postDate: new Date("2024-01-15"),
-      expireDate: new Date("2024-02-15"),
-      jobDescription: "Develop and maintain software solutions.",
-      employmentType: "full-time",
-      compensationType: "paid",
-      jobStatus: "Open",
-      url: "https://techcorp.com/jobs/software-engineer",
-    },
-    {
-      _id: "2",
-      organizationName: "InnovateX",
-      organizationIndustry: "Product Development",
-      title: "Product Manager",
-      postDate: new Date("2024-01-10"),
-      expireDate: new Date("2024-02-10"),
-      jobDescription: "Lead product development initiatives.",
-      employmentType: "part-time",
-      compensationType: "paid",
-      jobStatus: "Open",
-      url: "https://innovatex.com/careers/product-manager",
-    },
-    {
-      _id: "3",
-      organizationName: "Creative Solutions",
-      organizationIndustry: "Design",
-      title: "UX Designer",
-      postDate: new Date("2024-01-20"),
-      expireDate: new Date("2024-03-01"),
-      jobDescription: "Design user experiences and interfaces.",
-      employmentType: "full-time",
-      compensationType: "volunteer",
-      jobStatus: "Open",
-      url: "https://creativesolutions.com/jobs/ux-designer",
-    },
-  ]);
+  const [recentJobs, setRecentJobs] = useState<IJob[]>([]);
 
   useEffect(() => {
     const fetchData = async () => {
       const response = await fetch("/api/jobs");
       const result = await response.json();
       setJobData(result);
-    };
 
+      // Get recent viewed job IDs from local storage
+      const raw = localStorage.getItem("myJobs");
+      const recentJobIds = raw ? JSON.parse(raw) : [];
+
+      // Query for recent jobs if one or more IDs are present
+      if (recentJobIds.length > 0) {
+        const recentJobsresponse = await fetch("/api/jobs/recent", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ rawJobIdArray: recentJobIds }),
+        });
+        const recentJobsResult = await recentJobsresponse.json();
+        setRecentJobs(recentJobsResult);
+      } else {
+        setRecentJobs([]);
+      }
+    };
     fetchData();
   }, []);
 

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -27,8 +27,6 @@ export default function Jobs() {
       const response = await fetch("/api/jobs");
       const result = await response.json();
       setJobData(result);
-
-      fetchRecentJobs();
     };
     fetchData();
   }, []);


### PR DESCRIPTION
## Developer: John Ieng

Closes #95 

### Pull Request Summary

Change recent jobs state to fetch job IDs from local storage and query database instead of displaying hard-coded jobs. Note: There was an issue with the recently viewed tab not updating unless a refresh was made. This was due to the handler updating the local storage on the prop component, but not updating the parent component as well. To address this, I initiated a refresh of local storage when clicking on the "recently reviewed" tab. 

However, if you'd prefer I pass a handler as a prop to update the parent component, I can do that although it seems more inefficient.

### Modifications

`/src/app/jobs/page.tsx`: Change 

### Testing Considerations

Reset local storage, then click on "see more" on a few jobs and verify they were displayed on recently viewed.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

https://github.com/user-attachments/assets/c0620a28-23fb-4739-9d2c-aafae936c6e3


