### PR TITLE
98 apply with email template

### DIFF
--- a/src/components/JobCard/JobCard.tsx
+++ b/src/components/JobCard/JobCard.tsx
@@ -20,18 +20,6 @@ export default function JobCard({ job }: JobCardProps) {
     localStorage.setItem("myJobs", JSON.stringify(recentJobs));
   }, [recentJobs]);
 
-  const handleButtonClick = () => {
-    const newJob = job._id;
-    const arr = getRecentJobs();
-
-    if (!recentJobs.includes(newJob)) {
-      arr.push(newJob);
-    }
-
-    setRecentJobs(arr);
-    console.log(getRecentJobs());
-  };
-
   const getRecentJobs = () => {
     const storedJobs = localStorage.getItem("myJobs");
     if (storedJobs) {
@@ -68,15 +56,6 @@ export default function JobCard({ job }: JobCardProps) {
         </div>
         <div className="flex lg:flex-row flex-col gap-4 my-5">
           <Button
-            // old
-
-            // onClick={handleButtonClick}
-            // className="lg:w-[50%] w-full"
-            // fontWeight="normal"
-            // variant="outline"
-            // borderColor="black"
-
-            // new
             as="a"
             href={job.detailURL}
             className="lg:w-[50%] w-full"
@@ -87,19 +66,6 @@ export default function JobCard({ job }: JobCardProps) {
             See More
           </Button>
           <Button
-            //old
-
-            // onClick={handleButtonClick}
-            // className="lg:w-[50%] w-full"
-            // fontWeight="normal"
-            // variant="outline"
-            // bg="black"
-            // textColor="white"
-            // _hover={{
-            //   bg: "gray.800",
-            // }}
-
-            // new
             onClick={handleApplyNowClick}
             className="lg:w-[50%] w-full"
             fontWeight="normal"

--- a/src/components/JobCard/JobCard.tsx
+++ b/src/components/JobCard/JobCard.tsx
@@ -20,14 +20,6 @@ export default function JobCard({ job }: JobCardProps) {
     localStorage.setItem("myJobs", JSON.stringify(recentJobs));
   }, [recentJobs]);
 
-  const getRecentJobs = () => {
-    const storedJobs = localStorage.getItem("myJobs");
-    if (storedJobs) {
-      return JSON.parse(storedJobs);
-    }
-    return [];
-  };
-
   // when user clicks apply it birngs them to a email with a custom email template
   const handleApplyNowClick = () => {
     // we first check if there is an actual URL, if so we bring the user there

--- a/src/components/JobCard/JobCard.tsx
+++ b/src/components/JobCard/JobCard.tsx
@@ -40,6 +40,21 @@ export default function JobCard({ job }: JobCardProps) {
     return [];
   };
 
+  // when user clicks apply it birngs them to a email with a custom email template
+  const handleApplyNowClick = () => {
+    // we first check if there is an actual URL, if so we bring the user there
+    if (job.applyNowURL) {
+      window.location.href = job.applyNowURL;
+
+      // custom emial template if no URL is present
+    } else {
+      const email = "jobposter@example.com"; // Dummy email, please replace with actual email
+      const subject = `Application for ${job.title}`;
+      const body = `Dear ${job.organizationName},%0D%0A%0D%0AI am interested in the ${job.title} position. Please find my application attached.%0D%0A%0D%0AThank you,%0D%0A[Your Name]`;
+      window.location.href = `mailto:${email}?subject=${subject}&body=${body}`;
+    }
+  };
+
   return (
     <div className="max-w-[100%]">
       <div className="bg-[#f7f7f7] rounded-md px-8 pt-5 pb-2 shadow-sm">
@@ -53,7 +68,17 @@ export default function JobCard({ job }: JobCardProps) {
         </div>
         <div className="flex lg:flex-row flex-col gap-4 my-5">
           <Button
-            onClick={handleButtonClick}
+            // old
+
+            // onClick={handleButtonClick}
+            // className="lg:w-[50%] w-full"
+            // fontWeight="normal"
+            // variant="outline"
+            // borderColor="black"
+
+            // new
+            as="a"
+            href={job.detailURL}
             className="lg:w-[50%] w-full"
             fontWeight="normal"
             variant="outline"
@@ -62,7 +87,20 @@ export default function JobCard({ job }: JobCardProps) {
             See More
           </Button>
           <Button
-            onClick={handleButtonClick}
+            //old
+
+            // onClick={handleButtonClick}
+            // className="lg:w-[50%] w-full"
+            // fontWeight="normal"
+            // variant="outline"
+            // bg="black"
+            // textColor="white"
+            // _hover={{
+            //   bg: "gray.800",
+            // }}
+
+            // new
+            onClick={handleApplyNowClick}
             className="lg:w-[50%] w-full"
             fontWeight="normal"
             variant="outline"

--- a/src/components/JobCard/JobCard.tsx
+++ b/src/components/JobCard/JobCard.tsx
@@ -1,83 +1,3 @@
-// import { Button } from "@chakra-ui/react";
-// import { IJob } from "@/database/jobSchema";
-// import JobBadge from "@/components/JobCard/JobBadge";
-// import JobCardInformation from "@/components/JobCard/JobCardInformation";
-// import JobPostedDate from "@/components/JobCard/JobPostedDate";
-// import { useState, useEffect } from "react";
-// import { get } from "http";
-
-// interface JobCardProps {
-//   job: IJob;
-// }
-
-// export default function JobCard({ job }: JobCardProps) {
-//   const [recentJobs, setRecentJobs] = useState<string[]>(() => {
-//     const storedJobs = localStorage.getItem("myJobs");
-//     return storedJobs ? JSON.parse(storedJobs) : [];
-//   });
-
-//   useEffect(() => {
-//     localStorage.setItem("myJobs", JSON.stringify(recentJobs));
-//   }, [recentJobs]);
-
-//   // when user clicks apply it birngs them to a email with a custom email template
-//   const handleApplyNowClick = () => {
-//     // we first check if there is an actual URL, if so we bring the user there
-//     if (job.applyNowURL) {
-//       // window.location.href = job.applyNowURL;
-//       window.open(job.applyNowURL, "_blank");
-
-//       // custom emial template if no URL is present
-//     } else {
-//       const email = "jobposter@example.com"; // Dummy email, please replace with actual email
-//       const subject = `Application for ${job.title}`;
-//       const body = `Dear ${job.organizationName},%0D%0A%0D%0AI am interested in the ${job.title} position. Please find my application attached.%0D%0A%0D%0AThank you,%0D%0A[Your Name]`;
-//       // window.location.href = `mailto:${email}?subject=${subject}&body=${body}`;
-//       window.open(`mailto:${email}?subject=${subject}&body=${body}`, "_blank");
-//     }
-//   };
-
-//   return (
-//     <div className="max-w-[100%]">
-//       <div className="bg-[#f7f7f7] rounded-md px-8 pt-5 pb-2 shadow-sm">
-//         <JobCardInformation job={job} />
-//         <div className="flex flex-row md:flex-col lg:flex-row gap-4 items-end lg:items-end md:items-start mt-5">
-//           <div className="flex gap-2">
-//             <JobBadge badgeType={job.employmentType} />
-//             <JobBadge badgeType={job.compensationType} />
-//           </div>
-//           <JobPostedDate date={job.postDate} />
-//         </div>
-//         <div className="flex lg:flex-row flex-col gap-4 my-5">
-//           <Button
-//             as="a"
-//             href={job.detailURL}
-//             className="lg:w-[50%] w-full"
-//             fontWeight="normal"
-//             variant="outline"
-//             borderColor="black"
-//           >
-//             See More
-//           </Button>
-//           <Button
-//             onClick={handleApplyNowClick}
-//             className="lg:w-[50%] w-full"
-//             fontWeight="normal"
-//             variant="outline"
-//             bg="black"
-//             textColor="white"
-//             _hover={{
-//               bg: "gray.800",
-//             }}
-//           >
-//             Apply Now
-//           </Button>
-//         </div>
-//       </div>
-//     </div>
-//   );
-// }
-
 import { Button } from "@chakra-ui/react";
 import { IJob } from "@/database/jobSchema";
 import JobBadge from "@/components/JobCard/JobBadge";
@@ -99,22 +19,17 @@ export default function JobCard({ job }: JobCardProps) {
     localStorage.setItem("myJobs", JSON.stringify(recentJobs));
   }, [recentJobs]);
 
-  // when user clicks apply it brings them to an email with a custom email template
   const handleApplyNowClick = () => {
-    // we first check if there is an actual URL, if so we bring the user there
     if (job.applyNowURL) {
       window.open(job.applyNowURL, "_blank");
-
-      // custom email template if no URL is present
     } else {
-      const email = "jobposter@example.com"; // Dummy email, please replace with actual email
+      const email = "jobposter@example.com";
       const subject = `Application for ${job.title}`;
       const body = `Dear ${job.organizationName},%0D%0A%0D%0AI am interested in the ${job.title} position. Please find my application attached.%0D%0A%0D%0AThank you,%0D%0A[Your Name]`;
-      window.open(`mailto:${email}?subject=${subject}&body=${body}`, "_blank");
+      window.location.href = `mailto:${email}?subject=${subject}&body=${body}`;
     }
   };
 
-  // when user clicks see more it opens the detail URL in a new tab
   const handleSeeMoreClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     event.preventDefault();
     window.open(job.detailURL, "_blank");

--- a/src/components/JobCard/JobCard.tsx
+++ b/src/components/JobCard/JobCard.tsx
@@ -1,10 +1,89 @@
+// import { Button } from "@chakra-ui/react";
+// import { IJob } from "@/database/jobSchema";
+// import JobBadge from "@/components/JobCard/JobBadge";
+// import JobCardInformation from "@/components/JobCard/JobCardInformation";
+// import JobPostedDate from "@/components/JobCard/JobPostedDate";
+// import { useState, useEffect } from "react";
+// import { get } from "http";
+
+// interface JobCardProps {
+//   job: IJob;
+// }
+
+// export default function JobCard({ job }: JobCardProps) {
+//   const [recentJobs, setRecentJobs] = useState<string[]>(() => {
+//     const storedJobs = localStorage.getItem("myJobs");
+//     return storedJobs ? JSON.parse(storedJobs) : [];
+//   });
+
+//   useEffect(() => {
+//     localStorage.setItem("myJobs", JSON.stringify(recentJobs));
+//   }, [recentJobs]);
+
+//   // when user clicks apply it birngs them to a email with a custom email template
+//   const handleApplyNowClick = () => {
+//     // we first check if there is an actual URL, if so we bring the user there
+//     if (job.applyNowURL) {
+//       // window.location.href = job.applyNowURL;
+//       window.open(job.applyNowURL, "_blank");
+
+//       // custom emial template if no URL is present
+//     } else {
+//       const email = "jobposter@example.com"; // Dummy email, please replace with actual email
+//       const subject = `Application for ${job.title}`;
+//       const body = `Dear ${job.organizationName},%0D%0A%0D%0AI am interested in the ${job.title} position. Please find my application attached.%0D%0A%0D%0AThank you,%0D%0A[Your Name]`;
+//       // window.location.href = `mailto:${email}?subject=${subject}&body=${body}`;
+//       window.open(`mailto:${email}?subject=${subject}&body=${body}`, "_blank");
+//     }
+//   };
+
+//   return (
+//     <div className="max-w-[100%]">
+//       <div className="bg-[#f7f7f7] rounded-md px-8 pt-5 pb-2 shadow-sm">
+//         <JobCardInformation job={job} />
+//         <div className="flex flex-row md:flex-col lg:flex-row gap-4 items-end lg:items-end md:items-start mt-5">
+//           <div className="flex gap-2">
+//             <JobBadge badgeType={job.employmentType} />
+//             <JobBadge badgeType={job.compensationType} />
+//           </div>
+//           <JobPostedDate date={job.postDate} />
+//         </div>
+//         <div className="flex lg:flex-row flex-col gap-4 my-5">
+//           <Button
+//             as="a"
+//             href={job.detailURL}
+//             className="lg:w-[50%] w-full"
+//             fontWeight="normal"
+//             variant="outline"
+//             borderColor="black"
+//           >
+//             See More
+//           </Button>
+//           <Button
+//             onClick={handleApplyNowClick}
+//             className="lg:w-[50%] w-full"
+//             fontWeight="normal"
+//             variant="outline"
+//             bg="black"
+//             textColor="white"
+//             _hover={{
+//               bg: "gray.800",
+//             }}
+//           >
+//             Apply Now
+//           </Button>
+//         </div>
+//       </div>
+//     </div>
+//   );
+// }
+
 import { Button } from "@chakra-ui/react";
 import { IJob } from "@/database/jobSchema";
 import JobBadge from "@/components/JobCard/JobBadge";
 import JobCardInformation from "@/components/JobCard/JobCardInformation";
 import JobPostedDate from "@/components/JobCard/JobPostedDate";
 import { useState, useEffect } from "react";
-import { get } from "http";
 
 interface JobCardProps {
   job: IJob;
@@ -20,19 +99,25 @@ export default function JobCard({ job }: JobCardProps) {
     localStorage.setItem("myJobs", JSON.stringify(recentJobs));
   }, [recentJobs]);
 
-  // when user clicks apply it birngs them to a email with a custom email template
+  // when user clicks apply it brings them to an email with a custom email template
   const handleApplyNowClick = () => {
     // we first check if there is an actual URL, if so we bring the user there
     if (job.applyNowURL) {
-      window.location.href = job.applyNowURL;
+      window.open(job.applyNowURL, "_blank");
 
-      // custom emial template if no URL is present
+      // custom email template if no URL is present
     } else {
       const email = "jobposter@example.com"; // Dummy email, please replace with actual email
       const subject = `Application for ${job.title}`;
       const body = `Dear ${job.organizationName},%0D%0A%0D%0AI am interested in the ${job.title} position. Please find my application attached.%0D%0A%0D%0AThank you,%0D%0A[Your Name]`;
-      window.location.href = `mailto:${email}?subject=${subject}&body=${body}`;
+      window.open(`mailto:${email}?subject=${subject}&body=${body}`, "_blank");
     }
+  };
+
+  // when user clicks see more it opens the detail URL in a new tab
+  const handleSeeMoreClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    event.preventDefault();
+    window.open(job.detailURL, "_blank");
   };
 
   return (
@@ -48,8 +133,7 @@ export default function JobCard({ job }: JobCardProps) {
         </div>
         <div className="flex lg:flex-row flex-col gap-4 my-5">
           <Button
-            as="a"
-            href={job.detailURL}
+            onClick={handleSeeMoreClick}
             className="lg:w-[50%] w-full"
             fontWeight="normal"
             variant="outline"

--- a/src/database/jobSchema.ts
+++ b/src/database/jobSchema.ts
@@ -47,7 +47,6 @@ const JobSchema = new Schema({
   employmentType: { type: String, enum: Object.values(EmploymentType), required: true },
   compensationType: { type: String, enum: Object.values(CompensationType), required: true },
   jobStatus: { type: String, enum: Object.values(JobStatus), required: true },
-  // url: { type: String, required: true },
   detailURL: { type: String, required: true },
   applyNowURL: { type: String }, // this field is optional
 });

--- a/src/database/jobSchema.ts
+++ b/src/database/jobSchema.ts
@@ -32,8 +32,8 @@ export interface IJob {
   compensationType: string;
   jobStatus: string;
   // url: string;
-  detailUrl: string;
-  applyNowUrl?: string; // applyNowUrl is optional
+  detailURL: string;
+  applyNowURL?: string; // applyNowUrl is optional
 }
 
 // Schema for the job object
@@ -47,7 +47,9 @@ const JobSchema = new Schema({
   employmentType: { type: String, enum: Object.values(EmploymentType), required: true },
   compensationType: { type: String, enum: Object.values(CompensationType), required: true },
   jobStatus: { type: String, enum: Object.values(JobStatus), required: true },
-  url: { type: String, required: true },
+  // url: { type: String, required: true },
+  detailURL: { type: String, required: true },
+  applyNowURL: { type: String }, // this field is optional
 });
 
 export default mongoose.models.Job || mongoose.model("Job", JobSchema);

--- a/src/database/jobSchema.ts
+++ b/src/database/jobSchema.ts
@@ -31,7 +31,9 @@ export interface IJob {
   employmentType: string;
   compensationType: string;
   jobStatus: string;
-  url: string;
+  // url: string;
+  detailUrl: string;
+  applyNowUrl?: string; // applyNowUrl is optional
 }
 
 // Schema for the job object

--- a/src/database/jobSchema.ts
+++ b/src/database/jobSchema.ts
@@ -31,9 +31,8 @@ export interface IJob {
   employmentType: string;
   compensationType: string;
   jobStatus: string;
-  // url: string;
   detailURL: string;
-  applyNowURL?: string; // applyNowUrl is optional
+  applyNowURL?: string;
 }
 
 // Schema for the job object


### PR DESCRIPTION
## Developer: Kyler Nord

Closes # https://github.com/hack4impact-calpoly/spokes/issues/98

### Pull Request Summary

I completed Issue 93

### Modifications

I modified the JobCard.tsx page so that it redirects the user to either the JobPosting link, or if that's not available it
opes their email with a premade email template. I also updated the job schema to support detailURL and applyNowURL.  The links now open up In new tabs and I cleaned up by comments

### Testing Considerations

I updated the dishwasher job from sparkling clean services on mongo DB ensuring that if a job posting link is present it directs the user there. See videos below for demo

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

https://github.com/user-attachments/assets/d3efd3be-c5c3-49ab-8a38-dc3cba622e47


https://github.com/user-attachments/assets/6502b43a-6f92-4085-9209-f6b89bb84371




