### PR TITLE
142 update job form to conditionally show compensation type

### DIFF
--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -49,7 +49,9 @@ export async function GET(req: Request) {
 
     if (compensationFilters.length > 0) {
       filter.compensationType = {
-        $in: compensationFilters,
+        $in: compensationFilters.includes("null")
+          ? [...compensationFilters.filter((c) => c !== "null"), null]
+          : compensationFilters,
       };
     }
 
@@ -88,7 +90,6 @@ export async function POST(request: Request) {
       !jobData.title ||
       !jobData.postDate ||
       !jobData.employmentType ||
-      !jobData.compensationType ||
       !jobData.jobStatus ||
       !jobData.detailURL
     ) {

--- a/src/app/api/send/route.ts
+++ b/src/app/api/send/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest) {
         organizationName: jobData.organizationName,
         organizationIndustry: jobData.organizationIndustry,
         employmentType: jobData.employmentType,
-        compensationType: jobData.compensationType,
+        compensationType: jobData.compensationType ?? "None",
         contactName: jobData.contactName,
         contactPhone: jobData.contactPhone,
         contactEmail: jobData.contactEmail,

--- a/src/app/jobform/JobFormPage.client.tsx
+++ b/src/app/jobform/JobFormPage.client.tsx
@@ -16,6 +16,7 @@ import {
   useRadioGroup,
   HStack,
   Link,
+  Collapse,
 } from "@chakra-ui/react";
 import RadioCard from "@/components/RadioCard";
 import TagSelect from "@/components/TagSelect";
@@ -25,7 +26,6 @@ import JobConfirmationModal from "@/components/JobConfirmationModal";
 import JobDeletedModal from "@/components/JobDeletedModal";
 import JobFailModal from "@/components/JobFailModal";
 
-// converts the formData string array to a Option object array necessary for use in the TagSelect componenet
 function formatIndustries(industries: string[]): Option[] {
   return industries.map((industry) => ({
     value: industry,
@@ -59,7 +59,7 @@ export default function JobFormPage() {
   });
 
   const [loading, setLoading] = useState(false);
-  const [loadingInfo, setLoadingInfo] = useState(isEditing); // for setting loading state of job info fetching
+  const [loadingInfo, setLoadingInfo] = useState(isEditing);
   const [message, setMessage] = useState("");
   const [selectEmployment, setSelectEmployment] = useState("");
   const [selectCompensation, setSelectCompensation] = useState("");
@@ -80,7 +80,6 @@ export default function JobFormPage() {
     Contract: "#FAC791",
   };
 
-  // if we have a jobId, fetch the existing job
   useEffect(() => {
     if (!jobId) return;
     const fetchJob = async () => {
@@ -115,14 +114,12 @@ export default function JobFormPage() {
     fetchJob();
   }, [jobId]);
 
-  // Reset form when resetForm state changes
   useEffect(() => {
     if (resetForm) {
       reset();
     }
   }, [resetForm, reset]);
 
-  // formats phone number input to filter non-numbers an add -
   const formatPhoneNumber = (value: string): string => {
     const cleaned = value.replace(/\D/g, "");
     const match = cleaned.match(/^(\d{3})(\d{0,3})(\d{0,4})$/);
@@ -144,7 +141,6 @@ export default function JobFormPage() {
     setLoading(true);
     setMessage("");
 
-    //set expire date to null
     const formattedFormData = {
       ...formData,
       expireDate: formData.expireDate ? formData.expireDate : null,
@@ -161,7 +157,6 @@ export default function JobFormPage() {
         throw new Error("Failed to submit job.");
       }
 
-      // send email noti to admin
       const emailResponse = await fetch("/api/send", {
         method: "POST",
         headers: {
@@ -204,7 +199,6 @@ export default function JobFormPage() {
     }
   };
 
-  // update -> (only if jobId)
   const handleUpdate = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!jobId) return;
@@ -237,7 +231,6 @@ export default function JobFormPage() {
     }
   };
 
-  // delete -> (only if jobId)
   const handleDelete = async () => {
     if (!jobId) return;
     setLoading(true);
@@ -269,18 +262,24 @@ export default function JobFormPage() {
     }
   };
 
-  //For custom radio selection buttons, job type field
   const typeOptions = ["Full-Time", "Part-Time", "Volunteer"];
   const { getRootProps: getJobRootProps, getRadioProps: getJobRadioProps } = useRadioGroup({
     name: "employmentType",
     value: selectEmployment,
     onChange: (value) => {
-      setFormData((prev) => ({ ...prev, employmentType: value.toLowerCase() }));
-      setSelectEmployment(value.toLowerCase());
+      const newType = value.toLowerCase();
+      setFormData((prev) => ({
+        ...prev,
+        employmentType: newType,
+        ...(newType === "volunteer" && { compensationType: "" }),
+      }));
+      setSelectEmployment(newType);
+      if (newType === "volunteer") {
+        setSelectCompensation("");
+      }
     },
   });
 
-  //For custom radio selection buttons, compensation type field
   const compensationOptions = ["Salary", "Hourly", "Contract"];
   const { getRootProps: getCompensationRootProps, getRadioProps: getCompensationRadioProps } = useRadioGroup({
     name: "compensationType",
@@ -397,25 +396,6 @@ export default function JobFormPage() {
             />
           </FormControl>
           <FormControl isRequired>
-            <FormLabel>Compensation Type</FormLabel>
-            <Stack direction={{ base: "column", md: "row" }} spacing={2} {...getCompensationRootProps()}>
-              {compensationOptions.map((value) => {
-                const radio = getCompensationRadioProps({ value });
-                return (
-                  <RadioCard
-                    key={value}
-                    value={value}
-                    {...radio}
-                    isChecked={selectCompensation === value.toLowerCase()}
-                    checkedColor={compensationColorMapping[value as keyof typeof compensationColorMapping]}
-                  >
-                    {value}
-                  </RadioCard>
-                );
-              })}
-            </Stack>
-          </FormControl>
-          <FormControl isRequired>
             <FormLabel>Employment Type</FormLabel>
             <Stack direction={{ base: "column", md: "row" }} spacing={2} {...getJobRootProps()}>
               {typeOptions.map((value) => {
@@ -434,6 +414,27 @@ export default function JobFormPage() {
               })}
             </Stack>
           </FormControl>
+          <Collapse in={selectEmployment !== "volunteer"} animateOpacity>
+            <FormControl isRequired={selectEmployment !== "volunteer"}>
+              <FormLabel>Compensation Type</FormLabel>
+              <Stack direction={{ base: "column", md: "row" }} spacing={2} {...getCompensationRootProps()}>
+                {compensationOptions.map((value) => {
+                  const radio = getCompensationRadioProps({ value });
+                  return (
+                    <RadioCard
+                      key={value}
+                      value={value}
+                      {...radio}
+                      isChecked={selectCompensation === value.toLowerCase()}
+                      checkedColor={compensationColorMapping[value as keyof typeof compensationColorMapping]}
+                    >
+                      {value}
+                    </RadioCard>
+                  );
+                })}
+              </Stack>
+            </FormControl>
+          </Collapse>
           <FormControl isRequired>
             <FormLabel>Job Description</FormLabel>
             <Input
@@ -509,7 +510,6 @@ export default function JobFormPage() {
             <FormErrorMessage>Please enter a valid email address.</FormErrorMessage>
           </FormControl>
           {isEditing ? (
-            // if editing, show update & delete
             <HStack>
               <Button
                 isLoading={loading}
@@ -537,7 +537,6 @@ export default function JobFormPage() {
               </Button>
             </HStack>
           ) : (
-            // if creating, show Submit
             <Button
               isLoading={loading}
               loadingText="Submitting..."

--- a/src/app/jobform/JobFormPage.client.tsx
+++ b/src/app/jobform/JobFormPage.client.tsx
@@ -416,7 +416,7 @@ export default function JobFormPage() {
           </FormControl>
           <Box w="full">
             <Collapse in={selectEmployment !== "volunteer"} animateOpacity>
-              <FormControl isRequired={selectEmployment !== "volunteer"} mt={4}>
+              <FormControl isRequired={false} mt={4}>
                 <FormLabel>Compensation Type</FormLabel>
                 <Stack direction={{ base: "column", md: "row" }} spacing={2} {...getCompensationRootProps()}>
                   {compensationOptions.map((value) => {

--- a/src/app/jobform/JobFormPage.client.tsx
+++ b/src/app/jobform/JobFormPage.client.tsx
@@ -414,7 +414,7 @@ export default function JobFormPage() {
               })}
             </Stack>
           </FormControl>
-          <Box w="full" align="left">
+          <Box w="full">
             <Collapse in={selectEmployment !== "volunteer"} animateOpacity>
               <FormControl isRequired={selectEmployment !== "volunteer"} mt={4}>
                 <FormLabel>Compensation Type</FormLabel>

--- a/src/app/jobform/JobFormPage.client.tsx
+++ b/src/app/jobform/JobFormPage.client.tsx
@@ -49,7 +49,7 @@ export default function JobFormPage() {
     expireDate: "",
     jobDescription: "",
     employmentType: "full-time",
-    compensationType: "paid",
+    compensationType: null as string | null, // Allow null for volunteer jobs
     jobStatus: "pending",
     contactName: "",
     contactPhone: "",
@@ -62,7 +62,7 @@ export default function JobFormPage() {
   const [loadingInfo, setLoadingInfo] = useState(isEditing);
   const [message, setMessage] = useState("");
   const [selectEmployment, setSelectEmployment] = useState("");
-  const [selectCompensation, setSelectCompensation] = useState("");
+  const [selectCompensation, setSelectCompensation] = useState<string | null>(null);
   const [isSubmitModalOpen, setIsSubmitModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isFailModalOpen, setIsFailModalOpen] = useState(false);
@@ -271,11 +271,11 @@ export default function JobFormPage() {
       setFormData((prev) => ({
         ...prev,
         employmentType: newType,
-        ...(newType === "volunteer" && { compensationType: "" }),
+        ...(newType === "volunteer" && { compensationType: null }),
       }));
       setSelectEmployment(newType);
       if (newType === "volunteer") {
-        setSelectCompensation("");
+        setSelectCompensation(null);
       }
     },
   });
@@ -283,7 +283,7 @@ export default function JobFormPage() {
   const compensationOptions = ["Salary", "Hourly", "Contract"];
   const { getRootProps: getCompensationRootProps, getRadioProps: getCompensationRadioProps } = useRadioGroup({
     name: "compensationType",
-    value: selectCompensation,
+    value: selectCompensation ?? undefined,
     onChange: (value) => {
       setFormData((prev) => ({ ...prev, compensationType: value.toLowerCase() }));
       setSelectCompensation(value.toLowerCase());

--- a/src/app/jobform/JobFormPage.client.tsx
+++ b/src/app/jobform/JobFormPage.client.tsx
@@ -397,7 +397,7 @@ export default function JobFormPage() {
           </FormControl>
           <FormControl isRequired>
             <FormLabel>Employment Type</FormLabel>
-            <Stack direction={{ base: "column", md: "row" }} spacing={2} {...getJobRootProps()}>
+            <Stack direction={{ base: "column", md: "row" }} spacing={2} {...getJobRootProps()} justify="flex-start">
               {typeOptions.map((value) => {
                 const radio = getJobRadioProps({ value });
                 return (
@@ -414,27 +414,29 @@ export default function JobFormPage() {
               })}
             </Stack>
           </FormControl>
-          <Collapse in={selectEmployment !== "volunteer"} animateOpacity>
-            <FormControl isRequired={selectEmployment !== "volunteer"}>
-              <FormLabel>Compensation Type</FormLabel>
-              <Stack direction={{ base: "column", md: "row" }} spacing={2} {...getCompensationRootProps()}>
-                {compensationOptions.map((value) => {
-                  const radio = getCompensationRadioProps({ value });
-                  return (
-                    <RadioCard
-                      key={value}
-                      value={value}
-                      {...radio}
-                      isChecked={selectCompensation === value.toLowerCase()}
-                      checkedColor={compensationColorMapping[value as keyof typeof compensationColorMapping]}
-                    >
-                      {value}
-                    </RadioCard>
-                  );
-                })}
-              </Stack>
-            </FormControl>
-          </Collapse>
+          <Box w="full" align="left">
+            <Collapse in={selectEmployment !== "volunteer"} animateOpacity>
+              <FormControl isRequired={selectEmployment !== "volunteer"} mt={4}>
+                <FormLabel>Compensation Type</FormLabel>
+                <Stack direction={{ base: "column", md: "row" }} spacing={2} {...getCompensationRootProps()}>
+                  {compensationOptions.map((value) => {
+                    const radio = getCompensationRadioProps({ value });
+                    return (
+                      <RadioCard
+                        key={value}
+                        value={value}
+                        {...radio}
+                        isChecked={selectCompensation === value.toLowerCase()}
+                        checkedColor={compensationColorMapping[value as keyof typeof compensationColorMapping]}
+                      >
+                        {value}
+                      </RadioCard>
+                    );
+                  })}
+                </Stack>
+              </FormControl>
+            </Collapse>
+          </Box>
           <FormControl isRequired>
             <FormLabel>Job Description</FormLabel>
             <Input

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -157,7 +157,10 @@ export default function Jobs() {
     Array.from(recentJobs)?.filter(
       (job) =>
         (filters.employment.length === 0 || filters.employment.includes(job.employmentType)) &&
-        (filters.compensation.length === 0 || filters.compensation.includes(job.compensationType)) &&
+        (filters.compensation.length === 0 ||
+          (job.compensationType
+            ? filters.compensation.includes(job.compensationType)
+            : filters.compensation.length === 0)) &&
         (filters.industry.length === 0 ||
           filters.industry.some((industry) => job.organizationIndustry.includes(industry))),
     );

--- a/src/components/JobCard/AdminCard.tsx
+++ b/src/components/JobCard/AdminCard.tsx
@@ -69,7 +69,7 @@ export default function AdminCard({ job, onUpdateJob, innerRef }: JobCardProps) 
         <div className="flex flex-wrap justify-between flex-row min-[1000px]:gap-4 gap-2 items-center">
           <div className="flex flex-wrap gap-2">
             <JobBadge badgeType={job.employmentType} />
-            <JobBadge badgeType={job.compensationType || ""} />
+            {job.compensationType && <JobBadge badgeType={job.compensationType} />}
           </div>
 
           <div className="flex flex-wrap gap-2 justify min-[1000px]:mt-0 mt-5">

--- a/src/components/JobCard/AdminCard.tsx
+++ b/src/components/JobCard/AdminCard.tsx
@@ -69,7 +69,7 @@ export default function AdminCard({ job, onUpdateJob, innerRef }: JobCardProps) 
         <div className="flex flex-wrap justify-between flex-row min-[1000px]:gap-4 gap-2 items-center">
           <div className="flex flex-wrap gap-2">
             <JobBadge badgeType={job.employmentType} />
-            <JobBadge badgeType={job.compensationType} />
+            <JobBadge badgeType={job.compensationType || ""} />
           </div>
 
           <div className="flex flex-wrap gap-2 justify min-[1000px]:mt-0 mt-5">

--- a/src/components/JobCard/JobCard.tsx
+++ b/src/components/JobCard/JobCard.tsx
@@ -58,7 +58,7 @@ export default function JobCard({ job, onJobView, innerRef }: JobCardProps) {
         <div className="flex flex-row md:flex-col lg:flex-row gap-4 items-end lg:items-end md:items-start mt-5">
           <div className="flex gap-2">
             <JobBadge badgeType={job.employmentType} />
-            <JobBadge badgeType={job.compensationType || ""} />
+            {job.compensationType && <JobBadge badgeType={job.compensationType} />}
           </div>
           <JobPostedDate date={job.postDate} />
         </div>

--- a/src/components/JobCard/JobCard.tsx
+++ b/src/components/JobCard/JobCard.tsx
@@ -58,7 +58,7 @@ export default function JobCard({ job, onJobView, innerRef }: JobCardProps) {
         <div className="flex flex-row md:flex-col lg:flex-row gap-4 items-end lg:items-end md:items-start mt-5">
           <div className="flex gap-2">
             <JobBadge badgeType={job.employmentType} />
-            <JobBadge badgeType={job.compensationType} />
+            <JobBadge badgeType={job.compensationType || ""} />
           </div>
           <JobPostedDate date={job.postDate} />
         </div>

--- a/src/database/jobSchema.ts
+++ b/src/database/jobSchema.ts
@@ -32,7 +32,7 @@ export interface IJob {
   approvedDate?: Date;
   jobDescription: string;
   employmentType: string;
-  compensationType: string;
+  compensationType?: string;
   jobStatus: string;
   contactName?: string;
   contactPhone?: string;
@@ -50,7 +50,7 @@ const JobSchema = new Schema({
   approvedDate: { type: Date, required: false },
   jobDescription: { type: String, required: true },
   employmentType: { type: String, enum: Object.values(EmploymentType), required: true },
-  compensationType: { type: String, enum: Object.values(CompensationType), required: true },
+  compensationType: { type: String, enum: Object.values(CompensationType), required: false },
   jobStatus: { type: String, enum: Object.values(JobStatus), required: true },
   contactName: { type: String, required: false },
   contactPhone: { type: String, required: false },


### PR DESCRIPTION
## Developer: Nolan Knievel

Closes #142

### Pull Request Summary
On job form, made the compensation type option collapse when user selects volunteer as employment type. 
Made compensation type optional in job schema and made it a non-required field in the job form. 


### Modifications
**JobFormPage.client.tsx** - wrapped compensation type FormControl in a Collapse component, having it disappear when volunteer is selected for employment type. 
Set CompensationType to null when volunteer option is selected and made necessary type changes to account for this. 


**JobSchema.tsx** - made compensationType optional in both JobSchema and IJob

**api/jobs/route** - updated GET and POST routes to account for a possible null compensation type

**api/send/route** - updated email route to account for a possible null compensation type

**components/JobCard/Admincard**
**components/JobCard/Jobcard** - conditionally render compensation type JobBadge, having it disappear if compensation type is null

### Testing Considerations
Have thoroughly tested the front end on my device. I'd recommend checking compensation type is being properly included in submitted job forms. 

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
<img width="1470" alt="Screen Shot 2025-03-29 at 5 51 27 PM" src="https://github.com/user-attachments/assets/4cd51308-f027-40d2-a737-d945b4d52ec4" />
<img width="1470" alt="Screen Shot 2025-03-29 at 5 51 23 PM" src="https://github.com/user-attachments/assets/460d4e63-06e2-47fb-ba23-94d9dba0f166" />



