### PR TITLE
167 fixed height for job cards

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -172,18 +172,7 @@ export default function AdminJobs() {
             ) : (
               <ChakraCarousel gap={20}>
                 {incomingJobData && incomingJobData.length > 0 ? (
-                  incomingJobData.map((job) => (
-                    <Flex
-                      key={job._id}
-                      justifyContent="space-between"
-                      flexDirection="column"
-                      overflow="hidden"
-                      rounded={5}
-                      flex={1}
-                    >
-                      <AdminJobCard job={job} onUpdateJob={updateJobStatus} />
-                    </Flex>
-                  ))
+                  incomingJobData.map((job) => <AdminJobCard key={job._id} job={job} onUpdateJob={updateJobStatus} />)
                 ) : (
                   <div>No jobs available</div>
                 )}

--- a/src/components/JobCard/AdminCard.tsx
+++ b/src/components/JobCard/AdminCard.tsx
@@ -50,8 +50,8 @@ export default function AdminCard({ job, onUpdateJob, innerRef }: JobCardProps) 
   }
 
   return (
-    <div className="max-w-[100%]" ref={innerRef}>
-      <div className="relative bg-[#f7f7f7] rounded-3xl px-8 py-5 shadow-sm">
+    <div className="w-full h-full" ref={innerRef}>
+      <div className="relative bg-[#f7f7f7] rounded-3xl px-8 py-5 shadow-sm h-full flex flex-col">
         <IconButton
           aria-label="Edit Application"
           // eslint-disable-next-line react/jsx-no-undef

--- a/src/components/JobCard/AdminCard.tsx
+++ b/src/components/JobCard/AdminCard.tsx
@@ -66,6 +66,7 @@ export default function AdminCard({ job, onUpdateJob, innerRef }: JobCardProps) 
           <JobStatusBadge jobStatus={job.jobStatus} />
         </div>
         <JobCardInformation job={job} />
+        <div className="flex-grow"></div>
         <div className="flex flex-wrap justify-between flex-row min-[1000px]:gap-4 gap-2 items-center">
           <div className="flex flex-wrap gap-2">
             <JobBadge badgeType={job.employmentType} />

--- a/src/components/JobCard/JobCard.tsx
+++ b/src/components/JobCard/JobCard.tsx
@@ -53,8 +53,9 @@ export default function JobCard({ job, onJobView, innerRef }: JobCardProps) {
 
   return (
     <div className="max-w-[100%]" ref={innerRef}>
-      <div className="bg-[#f7f7f7] rounded-md px-8 pt-5 pb-2 shadow-sm">
+      <div className="bg-[#f7f7f7] rounded-md px-8 pt-5 pb-2 shadow-sm h-full flex flex-col">
         <JobCardInformation job={job} />
+        <div className="flex-grow"></div> {/* variable padding */}
         <div className="flex flex-row md:flex-col lg:flex-row gap-4 items-end lg:items-end md:items-start mt-5 max-[400px]:flex-col max-[400px]:items-start">
           <div className="flex gap-2">
             <JobBadge badgeType={job.employmentType} />

--- a/src/components/JobCard/JobCardInformation.tsx
+++ b/src/components/JobCard/JobCardInformation.tsx
@@ -1,34 +1,18 @@
-"use client";
-
 import { IJob } from "@/database/jobSchema";
-import { useEffect, useRef, useState } from "react";
 
 interface JobInformationProps {
   job: IJob;
 }
 
 export default function JobCardInformation({ job }: JobInformationProps) {
-  const industriesRef = useRef<HTMLParagraphElement>(null);
-  const [isMultiLine, setIsMultiLine] = useState(false);
-
-  useEffect(() => {
-    if (industriesRef.current) {
-      const lineHeight = parseInt(window.getComputedStyle(industriesRef.current).lineHeight);
-      const contentHeight = industriesRef.current.scrollHeight;
-      setIsMultiLine(contentHeight > lineHeight * 1.5);
-    }
-  }, [job.organizationIndustry]);
-
   return (
     <>
       <div className="mb-2">
         <h1 className="text-2xl font-bold truncate">{job.title}</h1>
         <p className="text-gray-700 font-semibold truncate">{job.organizationName}</p>
       </div>
-      <div className={`${isMultiLine ? "mb-2" : "pt-2 mb-6"}`}>
-        <p ref={industriesRef} className="text-gray-700 italic">
-          {job.organizationIndustry.join(", ")}
-        </p>
+      <div className="mb-2">
+        <p className="text-gray-700 italic">{job.organizationIndustry.join(", ")}</p>
       </div>
       <div className="mb-4">
         <p className="text-gray-700 overflow:s h-max-[150px] h-[90px] overflow-scroll no-scrollbar">

--- a/src/components/JobCard/JobCardInformation.tsx
+++ b/src/components/JobCard/JobCardInformation.tsx
@@ -1,18 +1,34 @@
+"use client";
+
 import { IJob } from "@/database/jobSchema";
+import { useEffect, useRef, useState } from "react";
 
 interface JobInformationProps {
   job: IJob;
 }
 
 export default function JobCardInformation({ job }: JobInformationProps) {
+  const industriesRef = useRef<HTMLParagraphElement>(null);
+  const [isMultiLine, setIsMultiLine] = useState(false);
+
+  useEffect(() => {
+    if (industriesRef.current) {
+      const lineHeight = parseInt(window.getComputedStyle(industriesRef.current).lineHeight);
+      const contentHeight = industriesRef.current.scrollHeight;
+      setIsMultiLine(contentHeight > lineHeight * 1.5);
+    }
+  }, [job.organizationIndustry]);
+
   return (
     <>
       <div className="mb-2">
         <h1 className="text-2xl font-bold truncate">{job.title}</h1>
         <p className="text-gray-700 font-semibold truncate">{job.organizationName}</p>
       </div>
-      <div className="mb-4">
-        <p className="text-gray-700 italic">{job.organizationIndustry.join(", ")}</p>
+      <div className={`${isMultiLine ? "mb-2" : "pt-2 mb-6"}`}>
+        <p ref={industriesRef} className="text-gray-700 italic">
+          {job.organizationIndustry.join(", ")}
+        </p>
       </div>
       <div className="mb-4">
         <p className="text-gray-700 overflow:s h-max-[150px] h-[90px] overflow-scroll no-scrollbar">


### PR DESCRIPTION
## Developer: Mark McGuire

Closes #167 

### Pull Request Summary

Slotted a "flex-grow" div into the cards which acts as variable padding, expanding to fill open space created by taller cards.

### Modifications

modified: `src/components/JobCard/AdminCard.tsx`
modified: `src/components/JobCard/JobCard.tsx`

### Testing Considerations

Resize the window to test. 

Note: I wasn't able to test the admin job cards because of a null checking error I fixed in my previous pr (I didn't want to modify the file again), so make sure it works with those too. 

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
<img width="1082" alt="Screenshot 2025-04-03 at 9 12 09 PM" src="https://github.com/user-attachments/assets/f3792793-ceb3-4d7b-9871-fa3dbc15f3d5" />

