### PR TITLE
UI fixes

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -185,8 +185,8 @@ export default function AdminJobs() {
             <div className="flex gap-8 w-full">
               <div
                 className={twMerge(
-                  "text-black text-2xl sm:text-3xl text-center cursor-pointer select-none",
-                  tab == 1 ? "font-semibold" : "font-normal text-[#C3C3C3]",
+                  "text-black text-2xl sm:text-3xl font-semibold text-center cursor-pointer select-none",
+                  tab == 1 ? "opacity-100" : "opacity-50",
                 )}
                 onClick={() => {
                   // Later add functionally to display listings
@@ -197,8 +197,8 @@ export default function AdminJobs() {
               </div>
               <div
                 className={twMerge(
-                  "text-black text-2xl sm:text-3xl text-center cursor-pointer select-none",
-                  tab == 2 ? "font-semibold" : "font-normal text-[#C3C3C3]",
+                  "text-black text-2xl sm:text-3xl font-semibold text-center cursor-pointer select-none",
+                  tab == 2 ? "opacity-100" : "opacity-50",
                 )}
                 onClick={() => {
                   // Later add functionally to display listings

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -229,34 +229,36 @@ export default function Jobs() {
               </div>
             )}
           </div>
-          {tab == 1 ? (
-            <>
-              {fetchedJobs ? (
-                <>
-                  <JobGrid jobs={fetchedJobs.pages.flat()} innerRef={ref} onJobView={handleJobView} />
-                  {isFetchingNextPage && <Loader size="xl" label="Loading more jobs..." />}
-                </>
-              ) : (
-                <Loader
-                  size="xl"
-                  label="Loading Jobs..."
-                  className="flex flex-col items-center justify-center gap-6 grow lg:-mt-28 mt-28"
-                />
-              )}
-            </>
-          ) : (
-            <>
-              {filteredRecentJobs ? (
-                <JobGrid jobs={filteredRecentJobs} onJobView={handleJobView} />
-              ) : (
-                <Loader
-                  size="xl"
-                  label="Loading Jobs..."
-                  className="flex flex-col items-center justify-center gap-6 grow lg:-mt-28 mt-28"
-                />
-              )}
-            </>
-          )}
+          <div className="flex flex-col gap-4">
+            {tab == 1 ? (
+              <>
+                {fetchedJobs ? (
+                  <>
+                    <JobGrid jobs={fetchedJobs.pages.flat()} innerRef={ref} onJobView={handleJobView} />
+                    {isFetchingNextPage && <Loader size="xl" label="Loading more jobs..." />}
+                  </>
+                ) : (
+                  <Loader
+                    size="xl"
+                    label="Loading Jobs..."
+                    className="flex flex-col items-center justify-center gap-6 grow pt-10"
+                  />
+                )}
+              </>
+            ) : (
+              <>
+                {filteredRecentJobs ? (
+                  <JobGrid jobs={filteredRecentJobs} onJobView={handleJobView} />
+                ) : (
+                  <Loader
+                    size="xl"
+                    label="Loading Jobs..."
+                    className="flex flex-col items-center justify-center gap-6 grow lg:-mt-28 mt-28"
+                  />
+                )}
+              </>
+            )}
+          </div>
         </div>
       </div>
 

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -204,8 +204,8 @@ export default function Jobs() {
             <div className="flex gap-8 max-[500px]:justify-center max-[500px]:gap-4">
               <div
                 className={twMerge(
-                  "text-black text-xl sm:text-2xl md:text-3xl cursor-pointer select-none",
-                  tab == 1 ? "font-semibold" : "font-normal text-[#C3C3C3]",
+                  "text-black text-xl sm:text-2xl md:text-3xl font-semibold cursor-pointer select-none",
+                  tab == 1 ? "opacity-100" : "opacity-50",
                 )}
                 onClick={() => handleTabChange(1)}
               >
@@ -213,8 +213,8 @@ export default function Jobs() {
               </div>
               <div
                 className={twMerge(
-                  "text-black text-xl sm:text-2xl md:text-3xl cursor-pointer select-none",
-                  tab == 2 ? "font-semibold" : "font-normal text-[#C3C3C3]",
+                  "text-black text-xl sm:text-2xl md:text-3xl font-semibold cursor-pointer select-none",
+                  tab == 2 ? "opacity-100" : "opacity-50",
                 )}
                 onClick={() => handleTabChange(2)}
               >

--- a/src/components/FilterCard.tsx
+++ b/src/components/FilterCard.tsx
@@ -117,14 +117,18 @@ export const FilterCard = forwardRef<HTMLDivElement, FilterCardProps>(
           </div>
           <div>
             <div
-              className="flex gap-1 items-center mb-1 text-lg font-semibold text-black select-none whitespace-nowrap hover:underline"
+              className="flex gap-1 items-center mb-1 text-lg font-semibold text-black select-none whitespace-nowrap hover:underline cursor-pointer"
               onClick={() => setIndustryOpen(!industryOpen)}
             >
               Industry
               {industryOpen ? <FiChevronUp /> : <FiChevronDown />}
             </div>
-            {industryOpen && (
-              <div className="flex flex-col gap-[2px]">
+            <div
+              className={`overflow-hidden transition-all duration-300 ease-in-out ${
+                industryOpen ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"
+              }`}
+            >
+              <div className="flex flex-col gap-[2px] pt-1">
                 {industries.map((industry) => (
                   <Checkbox
                     key={industry}
@@ -134,7 +138,7 @@ export const FilterCard = forwardRef<HTMLDivElement, FilterCardProps>(
                   />
                 ))}
               </div>
-            )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/JobGrid.tsx
+++ b/src/components/JobGrid.tsx
@@ -41,7 +41,7 @@ interface NoJobsFoundProps {
 function NoJobsFound({ isAdmin }: NoJobsFoundProps) {
   if (isAdmin) {
     return (
-      <div className="grow flex flex-col gap-1 justify-center justify-self-center items-center mt-10">
+      <div className="grow flex flex-col gap-1 justify-center justify-self-center items-center min-h-[400px]">
         <h1 className="text-2xl font-bold">No Jobs Found</h1>
       </div>
     );

--- a/src/components/JobGrid.tsx
+++ b/src/components/JobGrid.tsx
@@ -48,7 +48,7 @@ function NoJobsFound({ isAdmin }: NoJobsFoundProps) {
   }
 
   return (
-    <div className="grow flex flex-col gap-1 justify-center justify-self-center items-center mt-10">
+    <div className="grow flex flex-col gap-1 justify-center justify-self-center items-center min-h-[400px]">
       <h1 className="text-3xl font-bold">No Jobs Found</h1>
       <p className="text-lg text-center">Try again with some different filters!</p>
     </div>


### PR DESCRIPTION
## Developer: Mark McGuire

### Pull Request Summary

Couple changes here and there.
- Changed the tab switching from bolded/unbolded to high opacity/low opacity.
- Added min-h to the JobGrid returned div if no jobs were found, making spacing more consistent on the pages where JobGrid.
- Added small animation/ease-in to expanding the industry filters.
- Centering on jobs page so "no jobs found" text doesn't move down when viewport expands with filters.

### Modifications

**Tab Switching & Div Centering**
modified: `src/app/admin/page.tsx`
modified: `src/app/jobs/page.tsx`

**Industry Drop Down Ease In**
modified: `src/components/FilterCard.tsx`

**Min-h to JobGrid "no jobs"**
modified: `src/components/JobGrid.tsx`

### Testing Considerations

Mobile responsiveness should still be good, test the industry drop down, centering and min-h should look good.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers
