### PR TITLE
feat: app http protocol incase link does not have it

### DIFF
--- a/src/app/jobform/JobFormPage.client.tsx
+++ b/src/app/jobform/JobFormPage.client.tsx
@@ -34,6 +34,11 @@ function formatIndustries(industries: string[]): Option[] {
   }));
 }
 
+const ensureHttps = (url: string | undefined): string | undefined => {
+  if (!url) return url;
+  return url.startsWith("http://") || url.startsWith("https://") ? url : `https://${url}`;
+};
+
 export default function JobFormPage() {
   const { register, handleSubmit: formHandleSubmit, reset } = useForm();
   const router = useRouter();
@@ -147,17 +152,9 @@ export default function JobFormPage() {
 
     const formattedFormData = {
       ...formData,
-      expireDate: formData.expireDate ? formData.expireDate : null,
-      detailURL:
-        formData.detailURL && !formData.detailURL.startsWith("http://") && !formData.detailURL.startsWith("https://")
-          ? `https://${formData.detailURL}`
-          : formData.detailURL,
-      applyNowURL:
-        formData.applyNowURL &&
-        !formData.applyNowURL.startsWith("http://") &&
-        !formData.applyNowURL.startsWith("https://")
-          ? `https://${formData.applyNowURL}`
-          : formData.applyNowURL,
+      expireDate: formData.expireDate || null,
+      detailURL: ensureHttps(formData.detailURL),
+      applyNowURL: ensureHttps(formData.applyNowURL),
     };
 
     try {

--- a/src/app/jobform/JobFormPage.client.tsx
+++ b/src/app/jobform/JobFormPage.client.tsx
@@ -148,6 +148,16 @@ export default function JobFormPage() {
     const formattedFormData = {
       ...formData,
       expireDate: formData.expireDate ? formData.expireDate : null,
+      detailURL:
+        formData.detailURL && !formData.detailURL.startsWith("http://") && !formData.detailURL.startsWith("https://")
+          ? `https://${formData.detailURL}`
+          : formData.detailURL,
+      applyNowURL:
+        formData.applyNowURL &&
+        !formData.applyNowURL.startsWith("http://") &&
+        !formData.applyNowURL.startsWith("https://")
+          ? `https://${formData.applyNowURL}`
+          : formData.applyNowURL,
     };
 
     try {

--- a/src/components/JobCard/JobCard.tsx
+++ b/src/components/JobCard/JobCard.tsx
@@ -38,7 +38,7 @@ function JobCard({ job, onJobView, innerRef }: JobCardProps) {
     if (job.applyNowURL) {
       window.open(job.applyNowURL, "_blank");
     } else {
-      const email = "jobposter@example.com";
+      const email = job.contactEmail;
       const subject = `Application for ${job.title}`;
       const body = `Dear ${job.organizationName},%0D%0A%0D%0AI am interested in the ${job.title} position. Please find my application attached.%0D%0A%0D%0AThank you,%0D%0A[Your Name]`;
       window.location.href = `mailto:${email}?subject=${subject}&body=${body}`;


### PR DESCRIPTION
## Developer: Noah Giboney

Closes #198

### Pull Request Summary

Fixed the apply now url and detail url bug. What was happening was when a user inputed a link 'www.google.com'. This would open the link as a relative route to the local host. This shouldn't happen when a real job poster will likly copy and paste a link for their job submission, but just to make sure this doesnt happen i appended the 'http' protocol to the start of the two links insane they dont have it already.

### Modifications

components/JobCard/JobCard.tsx
jobform/JobFormPage.client.tsx

### Testing Considerations

Tested job with and with out apply now URL.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

