### PR TITLE
fix: links on job card open in new tab

### DIFF
--- a/src/components/JobCard/AdminCard.tsx
+++ b/src/components/JobCard/AdminCard.tsx
@@ -71,6 +71,7 @@ export default function AdminCard({ job, onUpdateJob, innerRef }: JobCardProps) 
           <Link
             href={job.detailURL}
             className="text-sm font-medium px-3 py-2 rounded-md text-gray-600 hover:text-gray-800 hover:bg-gray-200 transition-all duration-200 w-fit"
+            target="_blank"
           >
             View Job Details
           </Link>
@@ -79,6 +80,7 @@ export default function AdminCard({ job, onUpdateJob, innerRef }: JobCardProps) 
             <Link
               href={job.applyNowURL}
               className="text-sm font-medium px-3 py-2 rounded-md text-gray-600 hover:text-gray-800 hover:bg-gray-200 transition-all duration-200 w-fit"
+              target="_blank"
             >
               Apply Now
             </Link>


### PR DESCRIPTION
## Developer: Noah Giboney

### Pull Request Summary

Made admin card links open in new tab

