### PR TITLE
208 secure pages

### DIFF
--- a/src/components/NavBar/BottomSection.tsx
+++ b/src/components/NavBar/BottomSection.tsx
@@ -14,7 +14,7 @@ export default function BottomSection() {
   const pathname = usePathname();
   const { triggerReset } = useFormReset();
   const { orgSlug, isSignedIn } = useAuth();
-  const isSpokesAdmin = orgSlug === "test-admin";
+  const isSpokesAdmin = orgSlug === "spokes-admin";
 
   useEffect(() => {
     const handleScroll: EventListener = () => {
@@ -52,11 +52,16 @@ export default function BottomSection() {
       {/* Desktop Navigation (visible on sm and up) */}
       <div className="hidden sm:flex justify-between items-center px-9 py-.5 text-xs sm:text-sm md:text-md lg:text-lg">
         <div className="flex">
+          {/* dev/testing */}
           <NavBarLink title="Job Board" href="/jobs" />
           <NavBarLink title="List Job" href="/jobform" onClick={handleListJobClick} />
           <NavBarLink title="Dashboard" href="/dashboard" onClick={() => setIsMobileMenuOpen(false)} />
-          {/* uncomment this to only allow org admins, in the future we only want spokes admin on this page  */}
-          {/* {isSignedIn && isSpokesAdmin && <NavBarLink title="Spokes Dashboard" href="/admin" />} */}
+          <NavBarLink title="Spokes Dashboard" href="/admin" />
+          {/* prod */}
+          {/* <NavBarLink title="Job Board" href="/jobs" />
+          {isSignedIn && <NavBarLink title="List Job" href="/jobform" onClick={handleListJobClick} />}
+          {isSignedIn && <NavBarLink title="Dashboard" href="/dashboard" onClick={() => setIsMobileMenuOpen(false)} />}
+          {isSignedIn && isSpokesAdmin && <NavBarLink title="Spokes Dashboard" href="/admin" />} */}
         </div>
         {showScrollToTop && (
           <div
@@ -83,11 +88,15 @@ export default function BottomSection() {
             isMobileMenuOpen ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
           } space-y-1`}
         >
+          {/* dev/testing */}
           <NavBarLink title="Job Board" href="/jobs" onClick={() => setIsMobileMenuOpen(false)} />
           <NavBarLink title="List Job" href="/jobform" onClick={() => setIsMobileMenuOpen(false)} />
           <NavBarLink title="Dashboard" href="/dashboard" onClick={() => setIsMobileMenuOpen(false)} />
-          {/* uncomment this to only allow org admins, in the future we only want spokes admin on this page  */}
-          {/* {isSignedIn && isSpokesAdmin && (
+          <NavBarLink title="Spokes Dashboard" href="/admin" onClick={() => setIsMobileMenuOpen(false)} />
+          {/* prod */}
+          {/* {isSignedIn && <NavBarLink title="List Job" href="/jobform" onClick={() => setIsMobileMenuOpen(false)} />}
+          {isSignedIn && <NavBarLink title="Dashboard" href="/dashboard" onClick={() => setIsMobileMenuOpen(false)} />}
+          {isSignedIn && isSpokesAdmin && (
             <NavBarLink title="Spokes Dashboard" href="/admin" onClick={() => setIsMobileMenuOpen(false)} />
           )} */}
           {showScrollToTop && (

--- a/src/components/NavBar/BottomSection.tsx
+++ b/src/components/NavBar/BottomSection.tsx
@@ -13,7 +13,8 @@ export default function BottomSection() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const pathname = usePathname();
   const { triggerReset } = useFormReset();
-  const { has } = useAuth();
+  const { orgSlug, isSignedIn } = useAuth();
+  const isSpokesAdmin = orgSlug === "test-admin";
 
   useEffect(() => {
     const handleScroll: EventListener = () => {
@@ -55,7 +56,7 @@ export default function BottomSection() {
           <NavBarLink title="List Job" href="/jobform" onClick={handleListJobClick} />
           <NavBarLink title="Dashboard" href="/dashboard" onClick={() => setIsMobileMenuOpen(false)} />
           {/* uncomment this to only allow org admins, in the future we only want spokes admin on this page  */}
-          {has && has({ role: "org:admin" }) && <NavBarLink title="Spokes Dashboard" href="/admin" />}
+          {/* {isSignedIn && isSpokesAdmin && <NavBarLink title="Spokes Dashboard" href="/admin" />} */}
         </div>
         {showScrollToTop && (
           <div
@@ -86,9 +87,9 @@ export default function BottomSection() {
           <NavBarLink title="List Job" href="/jobform" onClick={() => setIsMobileMenuOpen(false)} />
           <NavBarLink title="Dashboard" href="/dashboard" onClick={() => setIsMobileMenuOpen(false)} />
           {/* uncomment this to only allow org admins, in the future we only want spokes admin on this page  */}
-          {has && has({ role: "org:admin" }) && (
+          {/* {isSignedIn && isSpokesAdmin && (
             <NavBarLink title="Spokes Dashboard" href="/admin" onClick={() => setIsMobileMenuOpen(false)} />
-          )}
+          )} */}
           {showScrollToTop && (
             <div
               onClick={() => {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,22 +15,18 @@ interface AuthWithRole {
  *
  * @returns {Promise<AuthWithRole>} Object containing userId and role
  */
-export async function getAuthWithRole(): Promise<AuthWithRole> {
-  const session = auth();
-
+export function getAuthWithRole({ userId, orgSlug }: { userId: string | null; orgSlug?: string | null }): AuthWithRole {
   //job-seekers will not be authenticated
-  if (!(await session)?.userId) {
+  if (!userId) {
     console.log("No user found, assigning job_seeker role");
     return { userId: null, role: "job_seeker" };
   }
 
-  const user = await session;
-  const userId = user.userId;
-
   // Check if user is part of spokes-admin organization
-  const isSpokesAdmin = user.orgSlug === "spokes-admin";
+  const isSpokesAdmin = orgSlug === "test-admin";
 
   if (isSpokesAdmin) {
+    console.log("User is", orgSlug);
     return { userId, role: "spokes_admin" };
   }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -23,7 +23,7 @@ export function getAuthWithRole({ userId, orgSlug }: { userId: string | null; or
   }
 
   // Check if user is part of spokes-admin organization
-  const isSpokesAdmin = orgSlug === "test-admin";
+  const isSpokesAdmin = orgSlug === "spokes-admin";
 
   if (isSpokesAdmin) {
     console.log("User is", orgSlug);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,16 +1,12 @@
 import { clerkMiddleware, createRouteMatcher, clerkClient } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
+import { getAuthWithRole } from "@/lib/auth";
 
 const isAdminRoute = createRouteMatcher(["/admin(.*)"]);
 const isOnboardingRoute = createRouteMatcher(["/onboarding"]);
 const isAuthRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)"]);
-const isPublicRoute = createRouteMatcher([
-  "/api/webhooks(.*)",
-  "/api/users(.*)",
-  "/jobs",
-  "/api/jobs(.*)",
-  "/admin(.*)",
-]);
+const isPublicRoute = createRouteMatcher(["/api/webhooks(.*)", "/api/users(.*)", "/jobs", "/api/jobs(.*)"]);
+const isNonprofitRoute = createRouteMatcher(["/dashboard(.*)"]);
 
 export default clerkMiddleware(async (auth, req) => {
   // if (isAdminRoute(req)) {
@@ -19,7 +15,8 @@ export default clerkMiddleware(async (auth, req) => {
   //   });
   // }
 
-  const { userId } = await auth();
+  const { userId, orgSlug } = await auth();
+  const { role } = getAuthWithRole({ userId, orgSlug });
 
   // if not signed in or on a public route, proceed normally
   if (isPublicRoute(req) || isAuthRoute(req)) {
@@ -48,6 +45,12 @@ export default clerkMiddleware(async (auth, req) => {
   if (onboardingComplete && isOnboardingRoute(req)) {
     const dashboardUrl = new URL("/", req.url);
     return NextResponse.redirect(dashboardUrl);
+  }
+
+  // if user trying to access admin, and is not spokes_admin
+  if (isAdminRoute(req) && !(role === "spokes_admin")) {
+    const jobUrl = new URL("/jobs", req.url);
+    return NextResponse.redirect(jobUrl);
   }
 
   return NextResponse.next();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,15 +6,8 @@ const isAdminRoute = createRouteMatcher(["/admin(.*)"]);
 const isOnboardingRoute = createRouteMatcher(["/onboarding"]);
 const isAuthRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)"]);
 const isPublicRoute = createRouteMatcher(["/api/webhooks(.*)", "/api/users(.*)", "/jobs", "/api/jobs(.*)"]);
-const isNonprofitRoute = createRouteMatcher(["/dashboard(.*)"]);
 
 export default clerkMiddleware(async (auth, req) => {
-  // if (isAdminRoute(req)) {
-  //   await auth.protect((has) => {
-  //     return has({ role: "org:admin" });
-  //   });
-  // }
-
   const { userId, orgSlug } = await auth();
   const { role } = getAuthWithRole({ userId, orgSlug });
 


### PR DESCRIPTION
## Developer: Ellie Pearson

Closes #208 

### Pull Request Summary

Secure the admin page so only users who are logged in and affiliated with the "spokes-admin" organization can see the Spokes admin page.

### Modifications

`src/middleware.ts` - added admin route logic and 
`src/lib/auth.ts` - edited getAuthWithRole to not use auth() since it kept getting a clerk middleware undetected error
`src/components/NavBar/BottomSection.tsx` - edited restriction to show the Spokes Dashboard link, commented for now so it is easier to test.


### Testing Considerations

- Tested accessing admin route as job seeker, nonprofit, and spokes admin
- Tested redirection to `/jobs` if not a spokes admin

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
