### PR TITLE
Refresh Button + Other Changes

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -17,6 +17,8 @@ export default function AdminJobs() {
   const [rejectedJobData, setRejectedJobData] = useState<null | IJob[]>(null);
   const [expiredJobData, setExpiredJobData] = useState<null | IJob[]>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isUpdatingJob, setIsUpdatingJob] = useState(false);
+  const [lastUpdateTime, setLastUpdateTime] = useState<number>(0);
 
   const setExpiredJobs = async (jobs: IJob[]) => {
     if (!Array.isArray(jobs)) {
@@ -88,6 +90,7 @@ export default function AdminJobs() {
     rejectionMessage?: string,
   ) => {
     try {
+      setIsUpdatingJob(true);
       // First fetch the current job data
       const response = await fetch(`/api/jobs/${jobId}`);
       if (!response.ok) {
@@ -135,18 +138,10 @@ export default function AdminJobs() {
       }
 
       // Remove the job from its current category
-      if (incomingJobData) {
-        setIncomingJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
-      }
-      if (liveJobData) {
-        setLiveJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
-      }
-      if (rejectedJobData) {
-        setRejectedJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
-      }
-      if (expiredJobData) {
-        setExpiredJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
-      }
+      setIncomingJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
+      setLiveJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
+      setRejectedJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
+      setExpiredJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
 
       if (status === "approved") {
         toast({
@@ -157,6 +152,7 @@ export default function AdminJobs() {
           isClosable: true,
           position: "top-right",
         });
+
         setLiveJobData((prev) => [...(prev ?? []), updatedJob]);
       } else if (status === "rejected") {
         toast({
@@ -167,6 +163,7 @@ export default function AdminJobs() {
           isClosable: true,
           position: "top-right",
         });
+
         setRejectedJobData((prev) => [...(prev ?? []), updatedJob]);
       } else if (status === "expired") {
         toast({
@@ -177,6 +174,7 @@ export default function AdminJobs() {
           isClosable: true,
           position: "top-right",
         });
+
         setExpiredJobData((prev) => [...(prev ?? []), updatedJob]);
       }
     } catch (error) {
@@ -189,6 +187,12 @@ export default function AdminJobs() {
         isClosable: true,
         position: "top-right",
       });
+    } finally {
+      setIsUpdatingJob(false);
+      // Set the last update time to now
+      setLastUpdateTime(Date.now());
+      // Wait for 2 seconds to ensure database consistency
+      await new Promise((resolve) => setTimeout(resolve, 2000));
     }
   };
 
@@ -196,6 +200,15 @@ export default function AdminJobs() {
 
   const handleRefresh = async () => {
     if (isRefreshing) return;
+
+    // check if we're within 2 seconds of the last update
+    const timeSinceLastUpdate = Date.now() - lastUpdateTime; // down the road change this hard coded 2 seconds to a more scalable solution
+    if (timeSinceLastUpdate < 2000) {
+      console.log("Waiting for database to sync...");
+      // wait for the remaining time
+      await new Promise((resolve) => setTimeout(resolve, 2000 - timeSinceLastUpdate));
+    }
+
     setIsRefreshing(true);
     await fetchData();
     setTimeout(() => {
@@ -324,10 +337,10 @@ export default function AdminJobs() {
               >
                 <button
                   onClick={handleRefresh}
-                  disabled={isRefreshing}
+                  disabled={isRefreshing || isUpdatingJob}
                   className={twMerge(
                     "p-2 hover:bg-gray-100 rounded-full transition-colors ml-auto group",
-                    isRefreshing && "cursor-not-allowed opacity-70",
+                    (isRefreshing || isUpdatingJob) && "cursor-not-allowed opacity-70",
                   )}
                 >
                   <svg

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -8,7 +8,7 @@ import { twMerge } from "tailwind-merge";
 import JobGridSkeleton from "@/components/JobGrid/JobGridSkeleton";
 import Link from "next/link";
 import { isExpired } from "@/lib/utils";
-import { useToast } from "@chakra-ui/react";
+import { Tooltip, useToast } from "@chakra-ui/react";
 
 export default function AdminJobs() {
   const toast = useToast();
@@ -134,41 +134,19 @@ export default function AdminJobs() {
         throw new Error("Failed to update job status");
       }
 
-      // Only update state after confirming the API call was successful
-      const updateState = () => {
-        // Remove the job from its current category
-        if (incomingJobData) {
-          setIncomingJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
-        }
-        if (liveJobData) {
-          setLiveJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
-        }
-        if (rejectedJobData) {
-          setRejectedJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
-        }
-        if (expiredJobData) {
-          setExpiredJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
-        }
-
-        // Add the job to its new category
-        switch (status) {
-          case "approved":
-            setLiveJobData((prev) => [...(prev ?? []), updatedJob]);
-            break;
-          case "rejected":
-            setRejectedJobData((prev) => [...(prev ?? []), updatedJob]);
-            break;
-          case "pending":
-            setIncomingJobData((prev) => [...(prev ?? []), updatedJob]);
-            break;
-          case "expired":
-            setExpiredJobData((prev) => [...(prev ?? []), updatedJob]);
-            break;
-        }
-      };
-
-      // Call updateState after successful API call
-      updateState();
+      // Remove the job from its current category
+      if (incomingJobData) {
+        setIncomingJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
+      }
+      if (liveJobData) {
+        setLiveJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
+      }
+      if (rejectedJobData) {
+        setRejectedJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
+      }
+      if (expiredJobData) {
+        setExpiredJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
+      }
 
       if (status === "approved") {
         toast({
@@ -179,6 +157,7 @@ export default function AdminJobs() {
           isClosable: true,
           position: "top-right",
         });
+        setLiveJobData((prev) => [...(prev ?? []), updatedJob]);
       } else if (status === "rejected") {
         toast({
           title: "Job Rejected",
@@ -188,6 +167,7 @@ export default function AdminJobs() {
           isClosable: true,
           position: "top-right",
         });
+        setRejectedJobData((prev) => [...(prev ?? []), updatedJob]);
       } else if (status === "expired") {
         toast({
           title: "Job Expired",
@@ -197,6 +177,7 @@ export default function AdminJobs() {
           isClosable: true,
           position: "top-right",
         });
+        setExpiredJobData((prev) => [...(prev ?? []), updatedJob]);
       }
     } catch (error) {
       console.error("Error updating job status:", error);
@@ -327,49 +308,63 @@ export default function AdminJobs() {
                 <span className="hidden sm:inline">Rejected Jobs</span>
                 <span className="sm:hidden">Rejected</span>
               </div>
-              <button
-                onClick={handleRefresh}
-                disabled={isRefreshing}
-                className={twMerge(
-                  "p-2 hover:bg-gray-100 rounded-full transition-colors ml-auto group",
-                  isRefreshing && "cursor-not-allowed opacity-70",
-                )}
-                title="Refresh job data"
+              <Tooltip
+                label={"Refresh job data"}
+                hasArrow
+                placement="top"
+                bg="#2B2B2B"
+                color="white"
+                fontSize="sm"
+                borderRadius="md"
+                padding="2"
+                boxShadow="md"
+                offset={[0, 5]}
+                maxW="220px"
+                openDelay={600}
               >
-                <svg
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
+                <button
+                  onClick={handleRefresh}
+                  disabled={isRefreshing}
                   className={twMerge(
-                    "text-gray-600 transition-transform duration-300 ease-in-out",
-                    isRefreshing && "animate-spin-once",
+                    "p-2 hover:bg-gray-100 rounded-full transition-colors ml-auto group",
+                    isRefreshing && "cursor-not-allowed opacity-70",
                   )}
                 >
-                  <path
-                    d="M23 4V10H17"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M1 20V14H7"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                  <path
-                    d="M3.51 9.00001C3.84797 7.58631 4.53047 6.28871 5.49997 5.20001C6.46947 4.11131 7.70047 3.26141 9.07097 2.71901C10.4415 2.17661 11.9075 1.95681 13.3745 2.07801C14.8415 2.19921 16.2645 2.65821 17.515 3.42001L23 8.00001M1 16L6.485 20.58C7.73547 21.3418 9.15847 21.8008 10.6255 21.922C12.0925 22.0432 13.5585 21.8234 14.929 21.281C16.2995 20.7386 17.5305 19.8887 18.5 18.8C19.4695 17.7113 20.152 16.4137 20.49 15"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </button>
+                  <svg
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    className={twMerge(
+                      "text-gray-600 transition-transform duration-300 ease-in-out",
+                      isRefreshing && "animate-spin-once",
+                    )}
+                  >
+                    <path
+                      d="M23 4V10H17"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M1 20V14H7"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M3.51 9.00001C3.84797 7.58631 4.53047 6.28871 5.49997 5.20001C6.46947 4.11131 7.70047 3.26141 9.07097 2.71901C10.4415 2.17661 11.9075 1.95681 13.3745 2.07801C14.8415 2.19921 16.2645 2.65821 17.515 3.42001L23 8.00001M1 16L6.485 20.58C7.73547 21.3418 9.15847 21.8008 10.6255 21.922C12.0925 22.0432 13.5585 21.8234 14.929 21.281C16.2995 20.7386 17.5305 19.8887 18.5 18.8C19.4695 17.7113 20.152 16.4137 20.49 15"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
+              </Tooltip>
             </div>
             {tab == 1 ? (
               liveJobData ? (

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -16,6 +16,7 @@ export default function AdminJobs() {
   const [liveJobData, setLiveJobData] = useState<null | IJob[]>(null);
   const [rejectedJobData, setRejectedJobData] = useState<null | IJob[]>(null);
   const [expiredJobData, setExpiredJobData] = useState<null | IJob[]>(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   const setExpiredJobs = async (jobs: IJob[]) => {
     if (!Array.isArray(jobs)) {
@@ -133,6 +134,42 @@ export default function AdminJobs() {
         throw new Error("Failed to update job status");
       }
 
+      // Only update state after confirming the API call was successful
+      const updateState = () => {
+        // Remove the job from its current category
+        if (incomingJobData) {
+          setIncomingJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
+        }
+        if (liveJobData) {
+          setLiveJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
+        }
+        if (rejectedJobData) {
+          setRejectedJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
+        }
+        if (expiredJobData) {
+          setExpiredJobData((prev) => prev?.filter((job) => job._id !== jobId) ?? []);
+        }
+
+        // Add the job to its new category
+        switch (status) {
+          case "approved":
+            setLiveJobData((prev) => [...(prev ?? []), updatedJob]);
+            break;
+          case "rejected":
+            setRejectedJobData((prev) => [...(prev ?? []), updatedJob]);
+            break;
+          case "pending":
+            setIncomingJobData((prev) => [...(prev ?? []), updatedJob]);
+            break;
+          case "expired":
+            setExpiredJobData((prev) => [...(prev ?? []), updatedJob]);
+            break;
+        }
+      };
+
+      // Call updateState after successful API call
+      updateState();
+
       if (status === "approved") {
         toast({
           title: "Job Approved",
@@ -175,6 +212,15 @@ export default function AdminJobs() {
   };
 
   const [tab, setTab] = useState(1);
+
+  const handleRefresh = async () => {
+    if (isRefreshing) return;
+    setIsRefreshing(true);
+    await fetchData();
+    setTimeout(() => {
+      setIsRefreshing(false);
+    }, 1000); // 1 second cooldown
+  };
 
   return (
     <div className="w-full">
@@ -281,6 +327,49 @@ export default function AdminJobs() {
                 <span className="hidden sm:inline">Rejected Jobs</span>
                 <span className="sm:hidden">Rejected</span>
               </div>
+              <button
+                onClick={handleRefresh}
+                disabled={isRefreshing}
+                className={twMerge(
+                  "p-2 hover:bg-gray-100 rounded-full transition-colors ml-auto group",
+                  isRefreshing && "cursor-not-allowed opacity-70",
+                )}
+                title="Refresh job data"
+              >
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className={twMerge(
+                    "text-gray-600 transition-transform duration-300 ease-in-out",
+                    isRefreshing && "animate-spin-once",
+                  )}
+                >
+                  <path
+                    d="M23 4V10H17"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M1 20V14H7"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M3.51 9.00001C3.84797 7.58631 4.53047 6.28871 5.49997 5.20001C6.46947 4.11131 7.70047 3.26141 9.07097 2.71901C10.4415 2.17661 11.9075 1.95681 13.3745 2.07801C14.8415 2.19921 16.2645 2.65821 17.515 3.42001L23 8.00001M1 16L6.485 20.58C7.73547 21.3418 9.15847 21.8008 10.6255 21.922C12.0925 22.0432 13.5585 21.8234 14.929 21.281C16.2995 20.7386 17.5305 19.8887 18.5 18.8C19.4695 17.7113 20.152 16.4137 20.49 15"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
             </div>
             {tab == 1 ? (
               liveJobData ? (

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -284,42 +284,44 @@ export default function AdminJobs() {
           </div>
 
           <div className="flex flex-col gap-8">
-            <div className="flex gap-8 w-full">
-              <div
-                className={twMerge(
-                  "text-black text-2xl sm:text-3xl font-semibold text-center cursor-pointer select-none",
-                  tab == 1 ? "opacity-100" : "opacity-50",
-                )}
-                onClick={() => {
-                  setTab(1);
-                }}
-              >
-                <span className="hidden sm:inline">Live Jobs</span>
-                <span className="sm:hidden">Live</span>
-              </div>
-              <div
-                className={twMerge(
-                  "text-black text-2xl sm:text-3xl font-semibold text-center cursor-pointer select-none",
-                  tab == 2 ? "opacity-100" : "opacity-50",
-                )}
-                onClick={() => {
-                  setTab(2);
-                }}
-              >
-                <span className="hidden sm:inline">Expired Jobs</span>
-                <span className="sm:hidden">Expired</span>
-              </div>
-              <div
-                className={twMerge(
-                  "text-black text-2xl sm:text-3xl font-semibold text-center cursor-pointer select-none",
-                  tab == 3 ? "opacity-100" : "opacity-50",
-                )}
-                onClick={() => {
-                  setTab(3);
-                }}
-              >
-                <span className="hidden sm:inline">Rejected Jobs</span>
-                <span className="sm:hidden">Rejected</span>
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div className="flex flex-wrap gap-4 sm:gap-8">
+                <div
+                  className={twMerge(
+                    "text-black text-xl sm:text-2xl md:text-3xl font-semibold text-center cursor-pointer select-none",
+                    tab == 1 ? "opacity-100" : "opacity-50",
+                  )}
+                  onClick={() => {
+                    setTab(1);
+                  }}
+                >
+                  <span className="hidden sm:inline">Live Jobs</span>
+                  <span className="sm:hidden">Live</span>
+                </div>
+                <div
+                  className={twMerge(
+                    "text-black text-xl sm:text-2xl md:text-3xl font-semibold text-center cursor-pointer select-none",
+                    tab == 2 ? "opacity-100" : "opacity-50",
+                  )}
+                  onClick={() => {
+                    setTab(2);
+                  }}
+                >
+                  <span className="hidden sm:inline">Expired Jobs</span>
+                  <span className="sm:hidden">Expired</span>
+                </div>
+                <div
+                  className={twMerge(
+                    "text-black text-xl sm:text-2xl md:text-3xl font-semibold text-center cursor-pointer select-none",
+                    tab == 3 ? "opacity-100" : "opacity-50",
+                  )}
+                  onClick={() => {
+                    setTab(3);
+                  }}
+                >
+                  <span className="hidden sm:inline">Rejected Jobs</span>
+                  <span className="sm:hidden">Rejected</span>
+                </div>
               </div>
               <Tooltip
                 label={"Refresh job data"}
@@ -339,7 +341,7 @@ export default function AdminJobs() {
                   onClick={handleRefresh}
                   disabled={isRefreshing || isUpdatingJob}
                   className={twMerge(
-                    "p-2 hover:bg-gray-100 rounded-full transition-colors ml-auto group",
+                    "p-2 hover:bg-gray-100 rounded-full transition-colors group",
                     (isRefreshing || isUpdatingJob) && "cursor-not-allowed opacity-70",
                   )}
                 >

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -14,7 +14,7 @@ export default function AdminJobs() {
   const toast = useToast();
   const [incomingJobData, setIncomingJobData] = useState<null | IJob[]>(null);
   const [liveJobData, setLiveJobData] = useState<null | IJob[]>(null);
-  const [completeJobData, setCompleteJobData] = useState<null | IJob[]>(null);
+  const [rejectedJobData, setRejectedJobData] = useState<null | IJob[]>(null);
   const [expiredJobData, setExpiredJobData] = useState<null | IJob[]>(null);
 
   const setExpiredJobs = async (jobs: IJob[]) => {
@@ -59,11 +59,11 @@ export default function AdminJobs() {
         return;
       }
 
-      const [incomingData, liveData, completeData, expiredData] = await Promise.all(responses.map((res) => res.json()));
+      const [incomingData, liveData, rejectedData, expiredData] = await Promise.all(responses.map((res) => res.json()));
 
       setIncomingJobData(incomingData);
       setLiveJobData(liveData);
-      setCompleteJobData(completeData);
+      setRejectedJobData(rejectedData);
       setExpiredJobData(expiredData);
     } catch (error) {
       console.error("Error fetching job data:", error);
@@ -161,9 +161,6 @@ export default function AdminJobs() {
           position: "top-right",
         });
       }
-
-      // Refetch all job data to update the UI
-      await fetchData();
     } catch (error) {
       console.error("Error updating job status:", error);
       toast({
@@ -254,7 +251,6 @@ export default function AdminJobs() {
                   tab == 1 ? "opacity-100" : "opacity-50",
                 )}
                 onClick={() => {
-                  // Later add functionally to display listings
                   setTab(1);
                 }}
               >
@@ -267,7 +263,6 @@ export default function AdminJobs() {
                   tab == 2 ? "opacity-100" : "opacity-50",
                 )}
                 onClick={() => {
-                  // Later add functionally to display listings
                   setTab(2);
                 }}
               >
@@ -280,7 +275,6 @@ export default function AdminJobs() {
                   tab == 3 ? "opacity-100" : "opacity-50",
                 )}
                 onClick={() => {
-                  // Later add functionally to display listings
                   setTab(3);
                 }}
               >
@@ -308,12 +302,16 @@ export default function AdminJobs() {
               ) : (
                 <JobGridSkeleton count={4} />
               )
-            ) : completeJobData ? (
-              <JobGrid
-                jobs={completeJobData}
-                isRejected={true}
-                onUpdateJob={(jobId, status, approvedDate) => updateJobStatus(jobId, status, approvedDate)}
-              />
+            ) : tab == 3 ? (
+              rejectedJobData ? (
+                <JobGrid
+                  jobs={rejectedJobData}
+                  isRejected={true}
+                  onUpdateJob={(jobId, status, approvedDate) => updateJobStatus(jobId, status, approvedDate)}
+                />
+              ) : (
+                <JobGridSkeleton count={4} />
+              )
             ) : (
               <JobGridSkeleton count={4} />
             )}

--- a/src/app/jobform/JobFormPage.client.tsx
+++ b/src/app/jobform/JobFormPage.client.tsx
@@ -17,6 +17,8 @@ import {
   Link,
   Collapse,
   useToast,
+  Spinner,
+  Text,
 } from "@chakra-ui/react";
 import RadioCard from "@/components/RadioCard";
 import TagSelect from "@/components/TagSelect";
@@ -778,56 +780,69 @@ export default function JobFormPage({ isSpokesAdmin, returnURL }: JobFormPagePro
           {isEditing ? (
             <div className="mt-10 bg-white p-6 rounded-lg border border-gray-200 shadow-sm">
               <div className="flex flex-col sm:flex-row gap-4 items-center justify-center">
-                {(!loading || action === "Update") && (
-                  <Button
-                    isLoading={loading && action === "Update"}
-                    loadingText="Updating..."
-                    type="submit"
-                    size="lg"
-                    colorScheme="blackAlpha"
-                    bg="#045F87"
-                    _hover={{ bg: "#2A80A8" }}
-                    className="w-full sm:w-auto min-w-[120px] shadow-sm"
-                    onClick={() => setAction("Update")}
-                  >
-                    Update
-                  </Button>
-                )}
-                {isSpokesAdmin && (!loading || action === "Reject") && (
-                  <Button
-                    isLoading={loading && action === "Reject"}
-                    loadingText="Rejecting..."
-                    size="lg"
-                    colorScheme="blackAlpha"
-                    bg="#FFF3E0"
-                    color="#C2410C"
-                    _hover={{ bg: "#FFE0B2" }}
-                    className="w-full sm:w-auto min-w-[120px] shadow-sm"
-                    onClick={() => {
-                      setIsRejectModalOpen(true);
-                      setAction("Reject");
-                    }}
-                  >
-                    Reject
-                  </Button>
-                )}
-                {(!loading || action === "Delete") && (
-                  <Button
-                    isLoading={loading && action === "Delete"}
-                    loadingText="Deleting..."
-                    size="lg"
-                    colorScheme="blackAlpha"
-                    bg="#FEE2E2"
-                    color="#991B1B"
-                    _hover={{ bg: "#FECACA" }}
-                    className="w-full sm:w-auto min-w-[120px] shadow-sm"
-                    onClick={() => {
-                      setIsActionConfirmationModalOpen(true);
-                      setAction("Delete");
-                    }}
-                  >
-                    Delete
-                  </Button>
+                {loadingInfo ? (
+                  <Box w="full" py={4}>
+                    <Stack direction="row" spacing={4} align="center" justify="center">
+                      <Spinner thickness="3px" speed="0.65s" emptyColor="gray.200" color="#045F87" size="md" />
+                      <Text color="gray.600" fontSize="md">
+                        Loading job information...
+                      </Text>
+                    </Stack>
+                  </Box>
+                ) : (
+                  <>
+                    {(!loading || action === "Update") && (
+                      <Button
+                        isLoading={loading && action === "Update"}
+                        loadingText="Updating..."
+                        type="submit"
+                        size="lg"
+                        colorScheme="blackAlpha"
+                        bg="#045F87"
+                        _hover={{ bg: "#2A80A8" }}
+                        className="w-full sm:w-auto min-w-[120px] shadow-sm"
+                        onClick={() => setAction("Update")}
+                      >
+                        Update
+                      </Button>
+                    )}
+                    {isSpokesAdmin && (!loading || action === "Reject") && (
+                      <Button
+                        isLoading={loading && action === "Reject"}
+                        loadingText="Rejecting..."
+                        size="lg"
+                        colorScheme="blackAlpha"
+                        bg="#FFF3E0"
+                        color="#C2410C"
+                        _hover={{ bg: "#FFE0B2" }}
+                        className="w-full sm:w-auto min-w-[120px] shadow-sm"
+                        onClick={() => {
+                          setIsRejectModalOpen(true);
+                          setAction("Reject");
+                        }}
+                      >
+                        Reject
+                      </Button>
+                    )}
+                    {(!loading || action === "Delete") && (
+                      <Button
+                        isLoading={loading && action === "Delete"}
+                        loadingText="Deleting..."
+                        size="lg"
+                        colorScheme="blackAlpha"
+                        bg="#FEE2E2"
+                        color="#991B1B"
+                        _hover={{ bg: "#FECACA" }}
+                        className="w-full sm:w-auto min-w-[120px] shadow-sm"
+                        onClick={() => {
+                          setIsActionConfirmationModalOpen(true);
+                          setAction("Delete");
+                        }}
+                      >
+                        Delete
+                      </Button>
+                    )}
+                  </>
                 )}
               </div>
             </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -56,6 +56,15 @@ module.exports = {
           5: "hsl(var(--chart-5))",
         },
       },
+      animation: {
+        "spin-once": "spin 2.2s cubic-bezier(0.34, 1.56, 0.64, 0.5)",
+      },
+      keyframes: {
+        spin: {
+          "0%": { transform: "rotate(0deg)" },
+          "100%": { transform: "rotate(360deg)" },
+        },
+      },
     },
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
## Developer: Mark McGuire

### Pull Request Summary

- **Refresh Button:** I found some cases where approvals/rejections/renewals weren't reflected in the admin dashboard until the page was refreshed so I just added a button to handle refetching the data. Not the most ideal fix but it works and we don't have much time.
- **Loading State for Edit Page Button Card:** added a loading state for the update/reject/delete buttons on the jobform edit page to prevent updates/rejections that get sent to the endpoint with no data loaded and inadvertently wipe the job.
- **Job Filtering:** Once an action is taken on a job, it is filtered out of the category it was previously in the state (I think this was implemented before and I accidentally removed it).

### Modifications

(see files changed)

### Testing Considerations

Tested full flow and trying to refresh right after an approval/rejection and everything works accordingly.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast
**Loading State**
<img width="537" alt="Screenshot 2025-06-03 at 8 44 32 PM" src="https://github.com/user-attachments/assets/9ff0c123-078c-4c2d-9f3c-fc0936d167a1" />

**Refresh Button**
<img width="193" alt="Screenshot 2025-06-03 at 8 44 23 PM" src="https://github.com/user-attachments/assets/3c8c7224-36e3-4c7f-8a83-59327b6d51ac" />
<img width="1433" alt="Screenshot 2025-06-03 at 8 44 13 PM" src="https://github.com/user-attachments/assets/0fd26fc6-1fed-4f37-9634-4bd072914957" />
